### PR TITLE
[SECURESIGN-1278] Extend e2e scenarios to cover TSA

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ This command will replace the existing `tas-env-variables.sh` script with the on
 You can also run the tests using `go test` command or using the [ginkgo](https://onsi.github.io/ginkgo/#installing-ginkgo) client.
 If you decide to do so, you need to set [ENV variables](#environment-setup)
 ```
-source tas-env-variables.sh && go test -v ./test/... --ginkgo.v
+source tas-env-variables.sh && go test -v ./test/...
 ```
 To run tests in specific directories:
 ```

--- a/pkg/api/values.go
+++ b/pkg/api/values.go
@@ -17,6 +17,7 @@ const (
 	TargetImageName  = "TARGET_IMAGE_NAME"
 	CosignImage      = "COSIGN_IMAGE"
 	RegistryImage    = "REGISTRY_IMAGE"
+	TsaURL           = "TSA_URL"
 
 	// 'DockerRegistry*' - Login credentials for 'registry.redhat.io'.
 	DockerRegistryUsername = "REGISTRY_USERNAME"

--- a/tas-env-variables.sh
+++ b/tas-env-variables.sh
@@ -15,6 +15,7 @@ export SIGSTORE_OIDC_ISSUER=$COSIGN_OIDC_ISSUER
 export SIGSTORE_REKOR_URL=$COSIGN_REKOR_URL
 export REKOR_REKOR_SERVER=$COSIGN_REKOR_URL
 export SIGSTORE_OIDC_CLIENT_ID=trusted-artifact-signer
+export TSA_URL=$(oc get timestampauthorities -o jsonpath='{.items[0].status.url}')/api/v1/timestamp
 
 # Print the environment variables to verify they are set
 echo "TUF_URL=$TUF_URL"
@@ -32,4 +33,5 @@ echo "SIGSTORE_OIDC_ISSUER=$SIGSTORE_OIDC_ISSUER"
 echo "SIGSTORE_REKOR_URL=$SIGSTORE_REKOR_URL"
 echo "REKOR_REKOR_SERVER=$REKOR_REKOR_SERVER"
 echo "SIGSTORE_OIDC_CLIENT_ID=$SIGSTORE_OIDC_CLIENT_ID"
+echo "TSA_URL=$TSA_URL"
 

--- a/test/cosign/cosign_sign_verify_test.go
+++ b/test/cosign/cosign_sign_verify_test.go
@@ -44,6 +44,7 @@ var _ = Describe("Cosign test", Ordered, func() {
 	)
 
 	BeforeAll(func() {
+		logrus.Infof("Starting cosign test")
 		err = testsupport.CheckMandatoryAPIConfigValues(api.OidcRealm)
 		if err != nil {
 			Skip("Skip this test - " + err.Error())
@@ -63,7 +64,6 @@ var _ = Describe("Cosign test", Ordered, func() {
 			}
 		})
 
-		// tempDir for publickey, signature, and predicate files
 		tempDir, err = os.MkdirTemp("", "tmp")
 		Expect(err).ToNot(HaveOccurred())
 

--- a/test/cosign/cosign_sign_verify_tsa_test.go
+++ b/test/cosign/cosign_sign_verify_tsa_test.go
@@ -94,10 +94,9 @@ var _ = Describe("TSA test", Ordered, func() {
 
 	Describe("download tsa chain", func() {
 		It("should download the tsa chain", func() {
-			tsaChainURL := api.GetValueFor(api.TsaURL) + "/certchain"
 			tsaChainPath = filepath.Join(tempDir, "ts_chain.pem")
 
-			resp, err := http.Get(tsaChainURL)
+			resp, err := http.Get(api.GetValueFor(api.TsaURL) + "/certchain")
 			Expect(err).ToNot(HaveOccurred())
 			defer resp.Body.Close()
 

--- a/test/cosign/cosign_sign_verify_tsa_test.go
+++ b/test/cosign/cosign_sign_verify_tsa_test.go
@@ -88,14 +88,13 @@ var _ = Describe("TSA test", Ordered, func() {
 		It("should sign the container using TSA", func() {
 			token, err := testsupport.GetOIDCToken(testsupport.TestContext, api.GetValueFor(api.OidcIssuerURL), "jdoe", "secure", api.GetValueFor(api.OidcRealm))
 			Expect(err).ToNot(HaveOccurred())
-			tsaURL := "https://freetsa.org/tsr"
-			Expect(cosign.Command(testsupport.TestContext, "sign", "-y", "--timestamp-server-url", tsaURL, "--identity-token="+token, tsaTargetImageName).Run()).To(Succeed())
+			Expect(cosign.Command(testsupport.TestContext, "sign", "-y", "--timestamp-server-url", api.GetValueFor(api.TsaURL), "--identity-token="+token, tsaTargetImageName).Run()).To(Succeed())
 		})
 	})
 
 	Describe("download tsa chain", func() {
 		It("should download the tsa chain", func() {
-			tsaChainURL := "https://freetsa.org/files/cacert.pem"
+			tsaChainURL := api.GetValueFor(api.TsaURL) + "/certchain"
 			tsaChainPath = filepath.Join(tempDir, "ts_chain.pem")
 
 			resp, err := http.Get(tsaChainURL)

--- a/test/cosign/cosign_sign_verify_tsa_test.go
+++ b/test/cosign/cosign_sign_verify_tsa_test.go
@@ -1,0 +1,121 @@
+package cosign
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/docker/docker/api/types/image"
+
+	"github.com/docker/docker/client"
+	"github.com/google/uuid"
+	"github.com/securesign/sigstore-e2e/pkg/api"
+	"github.com/securesign/sigstore-e2e/pkg/clients"
+	"github.com/securesign/sigstore-e2e/test/testsupport"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+)
+
+const tsaTestImage string = "alpine:latest"
+
+var tsaTargetImageName string
+var tsaChainPath string
+
+var _ = Describe("TSA test", Ordered, func() {
+
+	var (
+		err       error
+		dockerCli *client.Client
+		cosign    *clients.Cosign
+	)
+
+	BeforeAll(func() {
+		logrus.Infof("Starting TSA cosign test")
+		err = testsupport.CheckMandatoryAPIConfigValues(api.OidcRealm)
+		if err != nil {
+			Skip("Skip this test - " + err.Error())
+		}
+
+		cosign = clients.NewCosign()
+
+		Expect(testsupport.InstallPrerequisites(cosign)).To(Succeed())
+
+		DeferCleanup(func() {
+			if err := testsupport.DestroyPrerequisites(); err != nil {
+				logrus.Warn("Env was not cleaned-up" + err.Error())
+			}
+		})
+
+		tempDir, err = os.MkdirTemp("", "tmp")
+		Expect(err).ToNot(HaveOccurred())
+
+		manualImageSetup := api.GetValueFor(api.ManualImageSetup) == "true"
+		if !manualImageSetup {
+			tsaTargetImageName = "ttl.sh/" + uuid.New().String() + ":5m"
+			dockerCli, err = client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+			Expect(err).ToNot(HaveOccurred())
+
+			var pull io.ReadCloser
+			pull, err = dockerCli.ImagePull(testsupport.TestContext, tsaTestImage, image.PullOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			_, err = io.Copy(os.Stdout, pull)
+			Expect(err).ToNot(HaveOccurred())
+			defer pull.Close()
+
+			Expect(dockerCli.ImageTag(testsupport.TestContext, tsaTestImage, tsaTargetImageName)).To(Succeed())
+			var push io.ReadCloser
+			push, err = dockerCli.ImagePush(testsupport.TestContext, tsaTargetImageName, image.PushOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			_, err = io.Copy(os.Stdout, push)
+			Expect(err).ToNot(HaveOccurred())
+			defer push.Close()
+		} else {
+			tsaTargetImageName = api.GetValueFor(api.TargetImageName)
+			Expect(tsaTargetImageName).NotTo(BeEmpty(), "TARGET_IMAGE_NAME environment variable must be set when MANUAL_IMAGE_SETUP is true")
+		}
+	})
+
+	Describe("Cosign initialize", func() {
+		It("should initialize the cosign root", func() {
+			Expect(cosign.Command(testsupport.TestContext, "initialize").Run()).To(Succeed())
+		})
+	})
+
+	Describe("cosign sign tsa", func() {
+		It("should sign the container using TSA", func() {
+			token, err := testsupport.GetOIDCToken(testsupport.TestContext, api.GetValueFor(api.OidcIssuerURL), "jdoe", "secure", api.GetValueFor(api.OidcRealm))
+			Expect(err).ToNot(HaveOccurred())
+			tsaURL := "https://freetsa.org/tsr"
+			Expect(cosign.Command(testsupport.TestContext, "sign", "-y", "--timestamp-server-url", tsaURL, "--identity-token="+token, tsaTargetImageName).Run()).To(Succeed())
+		})
+	})
+
+	Describe("download tsa chain", func() {
+		It("should download the tsa chain", func() {
+			tsaChainURL := "https://freetsa.org/files/cacert.pem"
+			tsaChainPath = filepath.Join(tempDir, "ts_chain.pem")
+
+			resp, err := http.Get(tsaChainURL)
+			Expect(err).ToNot(HaveOccurred())
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				logrus.Fatal("failed to download TSA chain")
+			}
+
+			body, err := io.ReadAll(resp.Body)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(os.WriteFile(tsaChainPath, body, 0600)).To(Succeed())
+		})
+	})
+
+	Describe("cosign verify tsa", func() {
+		It("should verify the signature using TSA", func() {
+			Expect(cosign.Command(testsupport.TestContext, "verify", "--timestamp-certificate-chain", tsaChainPath, "--certificate-identity-regexp", ".*@redhat", "--certificate-oidc-issuer-regexp", ".*keycloak.*", tsaTargetImageName).Run()).To(Succeed())
+		})
+	})
+})

--- a/test/testsupport/test_support.go
+++ b/test/testsupport/test_support.go
@@ -36,7 +36,7 @@ var (
 	TestContext       context.Context
 	TestTimeoutMedium = 5 * time.Minute
 	// Config keys that must be defined for any test.
-	mandatoryAPIConfigKeys = []string{api.OidcIssuerURL, api.FulcioURL, api.RekorURL, api.TufURL}
+	mandatoryAPIConfigKeys = []string{api.OidcIssuerURL, api.FulcioURL, api.RekorURL, api.TufURL, api.TsaURL}
 )
 
 var installedStack []api.TestPrerequisite = make([]api.TestPrerequisite, 0)


### PR DESCRIPTION
I did consider splitting the tests into separate suites, but I decided to keep them together for now. If we prefer to have separate suites for clarity, we can revisit this decision.