### PR TITLE
skip tuftool openshift test on unsupported archs

### DIFF
--- a/pkg/clients/tuftool.go
+++ b/pkg/clients/tuftool.go
@@ -1,29 +1,14 @@
 package clients
 
-import "runtime"
-
 type Tuftool struct {
 	*cli
 }
 
 func NewTuftool() *Tuftool {
-	var setupStrategy SetupStrategy
-	switch runtime.GOOS {
-	case "linux":
-		switch runtime.GOARCH {
-		case "amd64":
-			setupStrategy = PreferredSetupStrategy()
-		default:
-			setupStrategy = LocalBinary()
-		}
-	default:
-		setupStrategy = LocalBinary()
-	}
-
 	return &Tuftool{
 		&cli{
 			Name:           "tuftool",
-			setupStrategy:  setupStrategy,
+			setupStrategy:  PreferredSetupStrategy(),
 			versionCommand: "--version",
 		}}
 }

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -35,11 +35,11 @@ test:
 	else \
 		echo ".env file not found, running tests without environment variables"; \
 	fi; \
-	go test -v ./test/... --ginkgo.v
+	go test -v ./test/...
 
 tuf-repo:
 	@echo "Running manual TUF repository test..."
-	go test -v ./test/tuftool --ginkgo.v
+	go test -v ./test/tuftool
 
 .PHONY: build test test-tuf-repo all 
  

--- a/test/tuftool/tuftool_manual_tuf_repo_test.go
+++ b/test/tuftool/tuftool_manual_tuf_repo_test.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
+	"github.com/securesign/sigstore-e2e/pkg/api"
 	"github.com/securesign/sigstore-e2e/pkg/clients"
 	"github.com/securesign/sigstore-e2e/test/testsupport"
 
@@ -40,6 +42,11 @@ var _ = Describe("TUF manual repo test", Ordered, func() {
 
 		tuftool = clients.NewTuftool()
 
+		openshiftStrategyActive := api.GetValueFor(api.CliStrategy) == "openshift"
+		if openshiftStrategyActive && (runtime.GOOS != "linux" || runtime.GOARCH != "amd64") {
+			logrus.Info("Skipping tuftool download test: openshift strategy is only supported on linux/amd64")
+			Skip("Skipping tuftool download test: openshift strategy is only supported on linux/amd64")
+		}
 		Expect(testsupport.InstallPrerequisites(tuftool)).To(Succeed())
 
 		DeferCleanup(func() {


### PR DESCRIPTION
skip tests for `CLI_STRATEGY=openshift` for all platforms except `linux/amd64`

makefile change because of `flag provided but not defined: -ginkgo.v`

