### PR TITLE
Entry index parsing improved

### DIFF
--- a/test/rekorcli/rekorcli_sign_verify_test.go
+++ b/test/rekorcli/rekorcli_sign_verify_test.go
@@ -101,10 +101,10 @@ var _ = Describe("Verify entries, query the transparency log for inclusion proof
 					if len(fields) == 2 {
 						key := strings.TrimSpace(fields[0])
 						value := strings.TrimSpace(fields[1])
-						switch key {
-						case "Entry Hash":
+
+						if strings.HasPrefix(key, "Entry Hash") {
 							rekorVerifyOutput.RekorHash = value
-						case "Entry Index":
+						} else if strings.HasPrefix(key, "Entry Index") {
 							entryIndex, err := strconv.Atoi(value)
 							if err != nil {
 								// Handle error


### PR DESCRIPTION
Entry index is taken from such a text:
```
Current Root Hash: c41dfd304c856578c70d5e3df30c2ec006b9520d6c318193cd598fcfa14a9188
Entry Hash: 94461160b4b91fc2f18c10ac536a6cd74961d4abf301ec9f8b0889f0a3a276cc
Entry Index in Current Tree: 5
Current Tree Size: 6
```

Entry index was always set to 0 in the test. This resulted in checking wrong entry when based on entry index.