### PR TITLE
add SIGSTORE_REKOR_UI_URL to .bat and .ps1 env scripts

### DIFF
--- a/tas-env-variables.bat
+++ b/tas-env-variables.bat
@@ -1,13 +1,14 @@
 @echo off
 
 REM Get the URLs and export them as environment variables
-for /f "tokens=*" %%i in ('oc get tuf -o jsonpath^="{.items[0].status.url}" -n trusted-artifact-signer') do set TUF_URL=%%i
+for /f "tokens=*" %%i in ('oc get tuf -o jsonpath^="{.items[0].status.url}"') do set TUF_URL=%%i
 for /f "tokens=*" %%i in ('oc get route keycloak -n keycloak-system --template^="{{.spec.host}}"') do set OIDC_ROUTE=%%i
 set OIDC_ISSUER_URL=https://%OIDC_ROUTE%/auth/realms/trusted-artifact-signer
-for /f "tokens=*" %%i in ('oc get fulcio -o jsonpath^="{.items[0].status.url}" -n trusted-artifact-signer') do set COSIGN_FULCIO_URL=%%i
-for /f "tokens=*" %%i in ('oc get rekor -o jsonpath^="{.items[0].status.url}" -n trusted-artifact-signer') do set COSIGN_REKOR_URL=%%i
-for /f "tokens=*" %%i in ('oc get timestampauthorities -o jsonpath^="{.items[0].status.url}" -n trusted-artifact-signer') do set TSA=%%i
+for /f "tokens=*" %%i in ('oc get fulcio -o jsonpath^="{.items[0].status.url}"') do set COSIGN_FULCIO_URL=%%i
+for /f "tokens=*" %%i in ('oc get rekor -o jsonpath^="{.items[0].status.url}"') do set COSIGN_REKOR_URL=%%i
+for /f "tokens=*" %%i in ('oc get timestampauthorities -o jsonpath^="{.items[0].status.url}"') do set TSA=%%i
 set TSA_URL=%TSA%/api/v1/timestamp
+for /f "tokens=*" %%i in ('oc get rekor -o jsonpath^="{.items[0].status.rekorSearchUIUrl}"') do set REKOR_UI_URL=%%i
 
 REM Print the URLs
 echo TUF_URL: %TUF_URL%
@@ -29,6 +30,7 @@ set SIGSTORE_REKOR_URL=%COSIGN_REKOR_URL%
 set REKOR_REKOR_SERVER=%COSIGN_REKOR_URL%
 set SIGSTORE_OIDC_CLIENT_ID=trusted-artifact-signer
 set TSA_URL=%TSA_URL%
+set SIGSTORE_REKOR_UI_URL=%REKOR_UI_URL%
 
 REM Print the environment variables to verify they are set
 echo TUF_URL: %TUF_URL%
@@ -47,3 +49,4 @@ echo SIGSTORE_REKOR_URL: %SIGSTORE_REKOR_URL%
 echo REKOR_REKOR_SERVER: %REKOR_REKOR_SERVER%
 echo SIGSTORE_OIDC_CLIENT_ID: %SIGSTORE_OIDC_CLIENT_ID%
 echo TSA_URL: %TSA_URL%
+echo SIGSTORE_REKOR_UI_URL: %SIGSTORE_REKOR_UI_URL%

--- a/tas-env-variables.ps1
+++ b/tas-env-variables.ps1
@@ -1,11 +1,12 @@
 # Get the URLs and export them as environment variables
-$TUF_URL = $(oc get tuf -o jsonpath='{.items[0].status.url}' -n trusted-artifact-signer)
+$TUF_URL = $(oc get tuf -o jsonpath='{.items[0].status.url}')
 $OIDC_ROUTE = $(oc get route keycloak -n keycloak-system --template='{{.spec.host}}')
 $OIDC_ISSUER_URL = "https://$OIDC_ROUTE/auth/realms/trusted-artifact-signer"
-$COSIGN_FULCIO_URL = $(oc get fulcio -o jsonpath='{.items[0].status.url}' -n trusted-artifact-signer)
-$COSIGN_REKOR_URL = $(oc get rekor -o jsonpath='{.items[0].status.url}' -n trusted-artifact-signer)
-$TSA = $(oc get timestampauthorities -o jsonpath='{.items[0].status.url}' -n trusted-artifact-signer)
+$COSIGN_FULCIO_URL = $(oc get fulcio -o jsonpath='{.items[0].status.url}')
+$COSIGN_REKOR_URL = $(oc get rekor -o jsonpath='{.items[0].status.url}')
+$TSA = $(oc get timestampauthorities -o jsonpath='{.items[0].status.url}')
 $TSA_URL = "$TSA/api/v1/timestamp"
+$REKOR_UI_URL = $(oc get rekor -o jsonpath='{.items[0].status.rekorSearchUIUrl}')
 
 # Print the URLs
 Write-Output "TUF_URL: $TUF_URL"
@@ -31,6 +32,7 @@ $env:SIGSTORE_REKOR_URL = $COSIGN_REKOR_URL
 $env:REKOR_REKOR_SERVER = $COSIGN_REKOR_URL
 $env:SIGSTORE_OIDC_CLIENT_ID = "trusted-artifact-signer"
 $env:TSA_URL = $TSA_URL
+$env:SIGSTORE_REKOR_UI_URL = $REKOR_UI_URL
 
 # Print the environment variables to verify they are set
 Write-Output "TUF_URL: $env:TUF_URL"
@@ -49,3 +51,4 @@ Write-Output "SIGSTORE_REKOR_URL: $env:SIGSTORE_REKOR_URL"
 Write-Output "REKOR_REKOR_SERVER: $env:REKOR_REKOR_SERVER"
 Write-Output "SIGSTORE_OIDC_CLIENT_ID: $env:SIGSTORE_OIDC_CLIENT_ID"
 Write-Output "TSA_URL: $env:TSA_URL"
+Write-Output "SIGSTORE_REKOR_UI_URL: $env:SIGSTORE_REKOR_UI_URL"


### PR DESCRIPTION
add `SIGSTORE_REKOR_UI_URL` to `.bat` and `.ps1` env scripts
remove `-n trusted-artifact-signer` so they can be found from other namespaces if necessary