### PR TITLE
test: run headless browser with no sandbox

### DIFF
--- a/test/rekorsearchui/rekor_search_sign_verify_test.go
+++ b/test/rekorsearchui/rekor_search_sign_verify_test.go
@@ -67,8 +67,10 @@ var _ = Describe("Test the Rekor Search UI", Ordered, func() {
 	appURL := api.GetValueFor(api.RekorUIURL)
 
 	setup := func() G {
-		headless := api.GetValueFor(api.HeadlessUI) == "true"
-		launch := launcher.New().Headless(headless)
+		launch := launcher.New()
+		if api.GetValueFor(api.HeadlessUI) == "true" {
+			launch = launch.Headless(true).NoSandbox(true)
+		}
 		url := launch.MustLaunch()
 		browser := rod.New().ControlURL(url).MustConnect()
 


### PR DESCRIPTION
## Summary by Sourcery

Enable no-sandbox mode for headless browser launches in Rekor Search UI tests.

Enhancements:
- Simplify launcher initialization by removing unused headless variable

Tests:
- Add NoSandbox flag to headless browser launcher when running headless