### PR TITLE
Release 1.3 fix

### DIFF
--- a/tas-env-variables.bat
+++ b/tas-env-variables.bat
@@ -2,8 +2,8 @@
 
 REM Get the URLs and export them as environment variables
 for /f "tokens=*" %%i in ('oc get tuf -o jsonpath^="{.items[0].status.url}"') do set TUF_URL=%%i
-for /f "tokens=*" %%i in ('oc get route keycloak -n keycloak-system --template^="{{.spec.host}}"') do set OIDC_ROUTE=%%i
-set OIDC_ISSUER_URL=https://%OIDC_ROUTE%/auth/realms/trusted-artifact-signer
+for /f "tokens=*" %%i in ('oc get route -n keycloak-system -l app^=keycloak -o jsonpath^="{.items[0].spec.host}"') do set OIDC_ROUTE=%%i
+set OIDC_ISSUER_URL=https://%OIDC_ROUTE%/realms/trusted-artifact-signer
 for /f "tokens=*" %%i in ('oc get fulcio -o jsonpath^="{.items[0].status.url}"') do set COSIGN_FULCIO_URL=%%i
 for /f "tokens=*" %%i in ('oc get rekor -o jsonpath^="{.items[0].status.url}"') do set COSIGN_REKOR_URL=%%i
 for /f "tokens=*" %%i in ('oc get timestampauthorities -o jsonpath^="{.items[0].status.url}"') do set TSA=%%i

--- a/tas-env-variables.ps1
+++ b/tas-env-variables.ps1
@@ -1,7 +1,7 @@
 # Get the URLs and export them as environment variables
 $TUF_URL = $(oc get tuf -o jsonpath='{.items[0].status.url}')
-$OIDC_ROUTE = $(oc get route keycloak -n keycloak-system --template='{{.spec.host}}')
-$OIDC_ISSUER_URL = "https://$OIDC_ROUTE/auth/realms/trusted-artifact-signer"
+$OIDC_ROUTE = $(oc get route -n keycloak-system -l app=keycloak -o jsonpath='{.items[0].spec.host}')
+$OIDC_ISSUER_URL = "https://$OIDC_ROUTE/realms/trusted-artifact-signer"
 $COSIGN_FULCIO_URL = $(oc get fulcio -o jsonpath='{.items[0].status.url}')
 $COSIGN_REKOR_URL = $(oc get rekor -o jsonpath='{.items[0].status.url}')
 $TSA = $(oc get timestampauthorities -o jsonpath='{.items[0].status.url}')

--- a/tas-env-variables.sh
+++ b/tas-env-variables.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ -z "$OIDC_ISSUER_URL" ]; then
-  export OIDC_ISSUER_URL=https://$(oc get route keycloak -n keycloak-system | tail -n 1 | awk '{print $2}')/auth/realms/trusted-artifact-signer
+  export OIDC_ISSUER_URL=https://$(oc get route -n keycloak-system -l app=keycloak -o jsonpath='{.items[0].status.ingress[0].host}')/realms/trusted-artifact-signer
 fi
 
 if [ -z "$TUF_URL" ]; then

--- a/test/rekorsearchui/rekor_search_sign_verify_test.go
+++ b/test/rekorsearchui/rekor_search_sign_verify_test.go
@@ -453,6 +453,35 @@ func (bt *BrowserTest) TestUUIDSearch() error {
 }
 
 func (bt *BrowserTest) TestCommitSHASearch() error {
+	// First navigate to check if crypto.subtle is available
+	if err := bt.Browser.Navigate(bt.URL); err != nil {
+		return err
+	}
+
+	// Check if crypto.subtle is available (required for commitSha search)
+	// crypto.subtle is only available in secure contexts (HTTPS, localhost)
+	cryptoCheck, err := bt.Browser.Page.Evaluate(`() => {
+		return {
+			available: typeof crypto !== 'undefined' && crypto.subtle !== undefined,
+			isSecureContext: window.isSecureContext
+		};
+	}`)
+	if err != nil {
+		return fmt.Errorf("failed to check crypto.subtle availability: %w", err)
+	}
+
+	checkResult, ok := cryptoCheck.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("unexpected crypto check result type")
+	}
+
+	available, _ := checkResult["available"].(bool)
+	isSecureContext, _ := checkResult["isSecureContext"].(bool)
+	if !available {
+		logrus.Warnf("Skipping commitSha test: crypto.subtle is not available (isSecureContext=%v, requires HTTPS or localhost)", isSecureContext)
+		return nil
+	}
+
 	return bt.performSearch("commitSha", `#rekor-search-commit\ sha`, bt.TestData.CommitSHA)
 }
 

--- a/test/rekorsearchui/rekor_search_sign_verify_test.go
+++ b/test/rekorsearchui/rekor_search_sign_verify_test.go
@@ -427,7 +427,7 @@ func (bt *BrowserTest) performSearch(attributeValue, inputID, searchValue string
 	if err := browser.Page.Locator(".pf-v5-c-card").
 		First().
 		WaitFor(playwright.LocatorWaitForOptions{
-			Timeout: playwright.Float(5_000),
+			Timeout: playwright.Float(15000),
 			State:   playwright.WaitForSelectorStateVisible,
 		}); err != nil {
 		return fmt.Errorf("no result cards became visible after search: %w", err)

--- a/test/tuftool/tuftool_manual_tuf_repo_test.go
+++ b/test/tuftool/tuftool_manual_tuf_repo_test.go
@@ -218,6 +218,7 @@ func verifyWorkdirStructure(rootPath string) {
 		".fulcio_v1.crt.pem",
 		".ctfe.pub",
 		".rekor.pub",
+		".signing_config.v0.2.json",
 	}
 
 	foundSuffixesCount := make(map[string]int)
@@ -280,9 +281,9 @@ func verifyWorkdirStructure(rootPath string) {
 	}
 
 	for suffix, count := range foundSuffixesCount {
-		if suffix == ".trusted_root.json" {
-			// Allow multiple .trusted_root.json files
-			Expect(count).To(BeNumerically(">=", 1), fmt.Sprintf("Expected at least one .trusted_root.json file, found %d", count))
+		if suffix == ".trusted_root.json" || suffix == ".signing_config.v0.2.json" {
+			// Allow multiple .trusted_root.json and .signing_config.v0.2.json files
+			Expect(count).To(BeNumerically(">=", 1), fmt.Sprintf("Expected at least one file with suffix %s, found %d", suffix, count))
 		} else {
 			// Ensure only one file for other suffixes
 			Expect(count).To(Equal(1), fmt.Sprintf("Expected exactly one file with suffix %s, found %d", suffix, count))


### PR DESCRIPTION
## Summary

Cherry-picks from main that are safe for 1.3.x (cosign 2.x):

- b03f8f9 fix: adding new signed target to tuftool tests (#56)
- dc2b40b fix: increase search result timeout from 5s to 15s (#57)
- d1adaa4 fix: skip commitsha if not available (requires https) (#58)
- a63837b fix: remove /auth from oidcUrl (#60)

Excludes cosign 3.0 changes (b171947, bdfbcdf) which are targeted
for 1.4.0

The /auth removal (#60) is needed because RHBK 26+ dropped the
/auth prefix from realm URLs.