### PR TITLE
fix: ignore HTTPS errors in Playwright browser context

### DIFF
--- a/test/rekorsearchui/rekor_search_sign_verify_test.go
+++ b/test/rekorsearchui/rekor_search_sign_verify_test.go
@@ -89,7 +89,8 @@ func createBrowser(browserType BrowserType, headless bool) (*Browser, error) {
 	}
 
 	contextOptions := playwright.BrowserNewContextOptions{
-		AcceptDownloads: playwright.Bool(true),
+		AcceptDownloads:   playwright.Bool(true),
+		IgnoreHttpsErrors: playwright.Bool(true),
 		Viewport: &playwright.Size{
 			Width:  1280,
 			Height: 720,


### PR DESCRIPTION
Hopefully fixes 

```
 failed to navigate to https://rekor-search-ui-sigstore-e2e-test.apps.bf6985e9-81ff-4fc9-8b57-796ae5358821.prod.konfluxeaas.com after 3 attempts
 ```
 
 in Konflux tas-e2e