### PR TITLE
fix: set explicit RHTAS service URLs in gitsign e2e test

### DIFF
--- a/test/gitsign/gitsign_sign_verify_test.go
+++ b/test/gitsign/gitsign_sign_verify_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Signing and verifying commits by using Gitsign from the comman
 		err    error
 	)
 	BeforeAll(func() {
-		err = testsupport.CheckMandatoryAPIConfigValues(api.OidcIssuerURL, api.RekorURL, api.TufURL)
+		err = testsupport.CheckMandatoryAPIConfigValues(api.OidcIssuerURL, api.RekorURL, api.TufURL, api.FulcioURL)
 		if err != nil {
 			Fail(err.Error())
 		}
@@ -94,6 +94,9 @@ var _ = Describe("Signing and verifying commits by using Gitsign from the comman
 			config.Raw.AddOption("tag", "", "gpgsign", "true")
 			config.Raw.AddOption("gpg", "x509", "program", "gitsign")
 			config.Raw.AddOption("gpg", "", "format", "x509")
+			config.Raw.AddOption("gitsign", "", "fulcio", api.GetValueFor(api.FulcioURL))
+			config.Raw.AddOption("gitsign", "", "rekor", api.GetValueFor(api.RekorURL))
+			config.Raw.AddOption("gitsign", "", "issuer", api.GetValueFor(api.OidcIssuerURL))
 
 			Expect(repo.SetConfig(config)).To(Succeed())
 		})


### PR DESCRIPTION
## Summary
- Adds explicit `gitsign.fulcio`, `gitsign.rekor`, and `gitsign.issuer` URLs to the git config in the gitsign e2e test, matching the pattern already used in the `rekorsearchui` test
- Adds `api.FulcioURL` to the mandatory config check so the test fails fast if the URL is missing

Without these, gitsign falls back to `fulcio.sigstore.dev` (public Sigstore), causing the test to fail when the RHTAS Keycloak OIDC token is rejected by the public Fulcio instance.

## Test plan
- [ ] Verify gitsign e2e test passes in CI against an RHTAS deployment
- [ ] Confirm no regression in rekorsearchui test (uses the same pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)