### PR TITLE
fix: retry cosign bundle download to handle registry propagation delay

### DIFF
--- a/test/cosign/cosign_sign_verify_test.go
+++ b/test/cosign/cosign_sign_verify_test.go
@@ -3,6 +3,7 @@ package cosign
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -125,20 +126,27 @@ var _ = Describe("Cosign test", Ordered, func() {
 			}
 
 			var bestBundle sigBundle
+			var lastErr error
 			logIndex = -1
-			const maxRetries = 5
+			const (
+				maxRetries = 5
+				retryDelay = 2 * time.Second
+			)
 			for attempt := 0; attempt < maxRetries; attempt++ {
 				if attempt > 0 {
-					time.Sleep(2 * time.Second)
+					logrus.Warnf("bundle download: attempt %d/%d (previous: %v)", attempt+1, maxRetries, lastErr)
+					time.Sleep(retryDelay)
 				}
 
 				bundleOutput, err := cosign.CommandOutput(testsupport.TestContext, "download", "signature", targetImageName)
 				if err != nil {
+					lastErr = fmt.Errorf("download failed: %w", err)
 					continue
 				}
 
 				startIdx := strings.Index(string(bundleOutput), "{")
 				if startIdx == -1 {
+					lastErr = fmt.Errorf("no JSON object in bundle output")
 					continue
 				}
 
@@ -164,8 +172,9 @@ var _ = Describe("Cosign test", Ordered, func() {
 				if logIndex >= 0 {
 					break
 				}
+				lastErr = fmt.Errorf("no bundle with valid tlog entry")
 			}
-			Expect(logIndex).To(BeNumerically(">=", 0), "no valid signature bundle found after retries")
+			Expect(logIndex).To(BeNumerically(">=", 0), fmt.Sprintf("no valid signature bundle found after %d attempts: %v", maxRetries, lastErr))
 
 			if len(bestBundle.DSSEEnvelope) > 0 {
 				dsseEnvelopePath = filepath.Join(tempDir, "dsse-envelope.json")

--- a/test/cosign/cosign_sign_verify_test.go
+++ b/test/cosign/cosign_sign_verify_test.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/docker/docker/api/types/image"
 
@@ -112,12 +113,8 @@ var _ = Describe("Cosign test", Ordered, func() {
 			// Extract logIndex by downloading signature bundles from the registry.
 			// Multiple bundles may exist if the image was signed more than once;
 			// pick the one with the highest logIndex (most recent).
-			bundleOutput, err := cosign.CommandOutput(testsupport.TestContext, "download", "signature", targetImageName)
-			Expect(err).ToNot(HaveOccurred())
-
-			startIdx := strings.Index(string(bundleOutput), "{")
-			Expect(startIdx).NotTo(Equal(-1), "JSON start - '{' not found in bundle output")
-
+			// Retry the download — the registry may not have propagated the
+			// signature immediately after signing.
 			type sigBundle struct {
 				VerificationMaterial struct {
 					TlogEntries []struct {
@@ -127,27 +124,48 @@ var _ = Describe("Cosign test", Ordered, func() {
 				DSSEEnvelope json.RawMessage `json:"dsseEnvelope"`
 			}
 
-			decoder := json.NewDecoder(strings.NewReader(string(bundleOutput[startIdx:])))
-			logIndex = -1
 			var bestBundle sigBundle
-			for decoder.More() {
-				var b sigBundle
-				if err := decoder.Decode(&b); err != nil {
-					break
+			logIndex = -1
+			const maxRetries = 5
+			for attempt := 0; attempt < maxRetries; attempt++ {
+				if attempt > 0 {
+					time.Sleep(2 * time.Second)
 				}
-				if len(b.VerificationMaterial.TlogEntries) == 0 {
-					continue
-				}
-				idx, err := strconv.Atoi(strings.Trim(string(b.VerificationMaterial.TlogEntries[0].LogIndex), "\""))
+
+				bundleOutput, err := cosign.CommandOutput(testsupport.TestContext, "download", "signature", targetImageName)
 				if err != nil {
 					continue
 				}
-				if idx > logIndex {
-					logIndex = idx
-					bestBundle = b
+
+				startIdx := strings.Index(string(bundleOutput), "{")
+				if startIdx == -1 {
+					continue
+				}
+
+				decoder := json.NewDecoder(strings.NewReader(string(bundleOutput[startIdx:])))
+				for decoder.More() {
+					var b sigBundle
+					if err := decoder.Decode(&b); err != nil {
+						break
+					}
+					if len(b.VerificationMaterial.TlogEntries) == 0 {
+						continue
+					}
+					idx, err := strconv.Atoi(strings.Trim(string(b.VerificationMaterial.TlogEntries[0].LogIndex), "\""))
+					if err != nil {
+						continue
+					}
+					if idx > logIndex {
+						logIndex = idx
+						bestBundle = b
+					}
+				}
+
+				if logIndex >= 0 {
+					break
 				}
 			}
-			Expect(logIndex).To(BeNumerically(">=", 0), "no valid signature bundle found")
+			Expect(logIndex).To(BeNumerically(">=", 0), "no valid signature bundle found after retries")
 
 			if len(bestBundle.DSSEEnvelope) > 0 {
 				dsseEnvelopePath = filepath.Join(tempDir, "dsse-envelope.json")


### PR DESCRIPTION
## Context
Saw that sometimes cosign tests fail with this
```
------------------------------
• [FAILED] [32.103 seconds]
Cosign test cosign sign [It] should sign the container
/Users/kdacosta/securesign/sigstore-e2e/test/cosign/cosign_sign_verify_test.go:106

  [FAILED] no valid signature bundle found
  Expected
      <int>: -1
  to be >=
      <int>: 0
  In [It] at: /Users/kdacosta/securesign/sigstore-e2e/test/cosign/cosign_sign_verify_test.go:150 @ 05/26/26 12:31:06.489
------------------------------
```

## Summary
- Wraps the `cosign download signature` call in a retry loop (up to 5 attempts, 2s between retries) to handle intermittent failures caused by registry propagation delay after signing
- The signature bundle may not be immediately available after `cosign sign` completes, leading to flaky "no valid signature bundle found" errors

## Test plan
- [ ] Run cosign sign/verify E2E test suite multiple times to confirm the flaky failure no longer reproduces
- [ ] Verify that the happy path (bundle available on first attempt) is not noticeably slower

🤖 Generated with [Claude Code](https://claude.com/claude-code)