### PR TITLE
fix: retry transient CI failures in e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,15 +45,6 @@ jobs:
         with:
           go-version-file: e2e/go.mod
 
-      - name: Resolve operator image
-        id: operator-image
-        run: |
-          if [ -n "${{ inputs.operator_image }}" ]; then
-            echo "img=${{ inputs.operator_image }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "img=registry.redhat.io/rhtas/rhtas-rhel9-operator:1.4.0" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Log in to GitHub Container Registry
         uses: redhat-actions/podman-login@v1
         with:
@@ -79,8 +70,17 @@ jobs:
           olm: "true"
           prometheus: "true"
 
-      - name: Pull operator image
-        run: podman pull ${{ steps.operator-image.outputs.img }}
+      - name: Build operator image
+        id: operator-image
+        run: |
+          if [ -n "${{ inputs.operator_image }}" ]; then
+            IMG="${{ inputs.operator_image }}"
+            podman pull "$IMG"
+          else
+            IMG="localhost/rhtas-operator:e2e"
+            make docker-build-skip-test IMG="$IMG" CONTAINER_TOOL=podman
+          fi
+          echo "img=$IMG" >> "$GITHUB_OUTPUT"
 
       - name: Load operator image into Kind
         run: |
@@ -90,7 +90,7 @@ jobs:
       - name: Deploy operator
         run: |
           make dev-images generate && cat config/default/images.env
-          IMG=${{ steps.operator-image.outputs.img }} make deploy
+          IMG=${{ steps.operator-image.outputs.img }} TARGET_PLATFORM=kubernetes make deploy
 
       - name: Wait for operator
         run: |

--- a/test/cosign/cosign_sign_verify_test.go
+++ b/test/cosign/cosign_sign_verify_test.go
@@ -100,7 +100,9 @@ var _ = Describe("Cosign test", Ordered, func() {
 
 	Describe("Cosign initialize", func() {
 		It("should initialize the TUF root", func() {
-			Expect(cosign.Command(testsupport.TestContext, "initialize").Run()).To(Succeed())
+			Eventually(func() error {
+				return cosign.Command(testsupport.TestContext, "initialize").Run()
+			}).WithTimeout(testsupport.CommandRetryTimeout).WithPolling(testsupport.CommandRetryInterval).Should(Succeed())
 		})
 	})
 
@@ -185,8 +187,10 @@ var _ = Describe("Cosign test", Ordered, func() {
 
 	Describe("cosign verify", func() {
 		It("should verify the signature", func() {
-			_, err := cosign.CommandOutput(testsupport.TestContext, "verify", "--certificate-identity-regexp", ".*"+regexp.QuoteMeta(api.GetValueFor(api.OidcUserDomain)), "--certificate-oidc-issuer-regexp", regexp.QuoteMeta(api.GetValueFor(api.OidcIssuerURL)), targetImageName)
-			Expect(err).ToNot(HaveOccurred())
+			Eventually(func() error {
+				_, err := cosign.CommandOutput(testsupport.TestContext, "verify", "--certificate-identity-regexp", ".*"+regexp.QuoteMeta(api.GetValueFor(api.OidcUserDomain)), "--certificate-oidc-issuer-regexp", regexp.QuoteMeta(api.GetValueFor(api.OidcIssuerURL)), targetImageName)
+				return err
+			}).WithTimeout(testsupport.CommandRetryTimeout).WithPolling(testsupport.CommandRetryInterval).Should(Succeed())
 		})
 	})
 
@@ -351,9 +355,11 @@ var _ = Describe("Cosign test", Ordered, func() {
 	Describe("ec validate", func() {
 		It("should initialize ec TUF root", func() {
 			tufURL := api.GetValueFor(api.TufURL)
-			Expect(ec.Command(testsupport.TestContext, "sigstore", "initialize",
-				"--mirror", tufURL,
-				"--root", tufURL+"/root.json").Run()).To(Succeed())
+			Eventually(func() error {
+				return ec.Command(testsupport.TestContext, "sigstore", "initialize",
+					"--mirror", tufURL,
+					"--root", tufURL+"/root.json").Run()
+			}).WithTimeout(testsupport.CommandRetryTimeout).WithPolling(testsupport.CommandRetryInterval).Should(Succeed())
 		})
 
 		It("should verify signature and attestation of the image", func() {

--- a/test/cosign/cosign_sign_verify_tsa_test.go
+++ b/test/cosign/cosign_sign_verify_tsa_test.go
@@ -76,7 +76,9 @@ var _ = Describe("TSA test", Ordered, func() {
 
 	Describe("Cosign initialize", func() {
 		It("should initialize the cosign root", func() {
-			Expect(cosign.Command(testsupport.TestContext, "initialize").Run()).To(Succeed())
+			Eventually(func() error {
+				return cosign.Command(testsupport.TestContext, "initialize").Run()
+			}).WithTimeout(testsupport.CommandRetryTimeout).WithPolling(testsupport.CommandRetryInterval).Should(Succeed())
 		})
 	})
 
@@ -90,7 +92,9 @@ var _ = Describe("TSA test", Ordered, func() {
 
 	Describe("cosign verify tsa", func() {
 		It("should verify the signature using TSA", func() {
-			Expect(cosign.Command(testsupport.TestContext, "verify", "--use-signed-timestamps", "--certificate-identity-regexp", ".*"+regexp.QuoteMeta(api.GetValueFor(api.OidcUserDomain)), "--certificate-oidc-issuer-regexp", regexp.QuoteMeta(api.GetValueFor(api.OidcIssuerURL)), tsaTargetImageName).Run()).To(Succeed())
+			Eventually(func() error {
+				return cosign.Command(testsupport.TestContext, "verify", "--use-signed-timestamps", "--certificate-identity-regexp", ".*"+regexp.QuoteMeta(api.GetValueFor(api.OidcUserDomain)), "--certificate-oidc-issuer-regexp", regexp.QuoteMeta(api.GetValueFor(api.OidcIssuerURL)), tsaTargetImageName).Run()
+			}).WithTimeout(testsupport.CommandRetryTimeout).WithPolling(testsupport.CommandRetryInterval).Should(Succeed())
 		})
 	})
 })

--- a/test/gitsign/gitsign_sign_verify_test.go
+++ b/test/gitsign/gitsign_sign_verify_test.go
@@ -75,9 +75,11 @@ var _ = Describe("Signing and verifying commits by using Gitsign from the comman
 	Describe("Gitsign initialize", func() {
 		It("should initialize the TUF root", func() {
 			tufURL := api.GetValueFor(api.TufURL)
-			Expect(gitsign.Command(testsupport.TestContext, "initialize",
-				"--mirror", tufURL,
-				"--root", tufURL+"/root.json").Run()).To(Succeed())
+			Eventually(func() error {
+				return gitsign.Command(testsupport.TestContext, "initialize",
+					"--mirror", tufURL,
+					"--root", tufURL+"/root.json").Run()
+			}).WithTimeout(testsupport.CommandRetryTimeout).WithPolling(testsupport.CommandRetryInterval).Should(Succeed())
 		})
 	})
 
@@ -135,18 +137,41 @@ var _ = Describe("Signing and verifying commits by using Gitsign from the comman
 	Describe("Verify the commit", func() {
 		When("commiter is authorized", func() {
 			It("should verify HEAD signature by gitsign", func() {
-				cmd := gitsign.Command(testsupport.TestContext, "verify",
-					"--certificate-identity", fmt.Sprintf("%s@%s", api.GetValueFor(api.OidcUser), api.GetValueFor(api.OidcUserDomain)),
-					"--certificate-oidc-issuer", api.GetValueFor(api.OidcIssuerURL),
-					"HEAD")
-
-				cmd.Dir = dir
-				cmd.Env = os.Environ()
-
+				// Retry gitsign verify — the TUF client's atomic temp-dir
+				// rename can race with disk I/O on CI runners.
+				const (
+					maxRetries = 5
+					retryDelay = 3 * time.Second
+				)
 				var output bytes.Buffer
+				var lastErr error
 
-				cmd.Stdout = &output
-				Expect(cmd.Run()).To(Succeed())
+				for attempt := 0; attempt < maxRetries; attempt++ {
+					if attempt > 0 {
+						logrus.Warnf("gitsign verify: attempt %d/%d (previous: %v)", attempt+1, maxRetries, lastErr)
+						time.Sleep(retryDelay)
+					}
+
+					cmd := gitsign.Command(testsupport.TestContext, "verify",
+						"--certificate-identity", fmt.Sprintf("%s@%s", api.GetValueFor(api.OidcUser), api.GetValueFor(api.OidcUserDomain)),
+						"--certificate-oidc-issuer", api.GetValueFor(api.OidcIssuerURL),
+						"HEAD")
+
+					cmd.Dir = dir
+					cmd.Env = os.Environ()
+
+					output.Reset()
+					cmd.Stdout = &output
+
+					if err := cmd.Run(); err != nil {
+						lastErr = fmt.Errorf("gitsign verify failed: %w", err)
+						continue
+					}
+					lastErr = nil
+					break
+				}
+				Expect(lastErr).ToNot(HaveOccurred(), fmt.Sprintf("gitsign verify failed after %d attempts", maxRetries))
+
 				logrus.WithField("app", "gitsign").Info(output.String())
 
 				re := regexp.MustCompile(`tlog index: (\d+)`)

--- a/test/rekorsearchui/rekor_search_sign_verify_test.go
+++ b/test/rekorsearchui/rekor_search_sign_verify_test.go
@@ -428,7 +428,7 @@ func (bt *BrowserTest) performSearch(attributeValue, inputID, searchValue string
 	if err := browser.Page.Locator(".pf-v5-c-card").
 		First().
 		WaitFor(playwright.LocatorWaitForOptions{
-			Timeout: playwright.Float(15000),
+			Timeout: playwright.Float(30000),
 			State:   playwright.WaitForSelectorStateVisible,
 		}); err != nil {
 		return fmt.Errorf("no result cards became visible after search: %w", err)
@@ -593,9 +593,11 @@ var _ = Describe("Test the Rekor Search UI", Ordered, func() {
 
 		Expect(exec.Command("tar", "-czvf", tarFilePath, dirFilePath).Run()).To(Succeed())
 		tufURL := api.GetValueFor(api.TufURL)
-		Expect(gitsign.Command(testsupport.TestContext, "initialize",
-			"--mirror", tufURL,
-			"--root", tufURL+"/root.json").Run()).To(Succeed())
+		Eventually(func() error {
+			return gitsign.Command(testsupport.TestContext, "initialize",
+				"--mirror", tufURL,
+				"--root", tufURL+"/root.json").Run()
+		}).WithTimeout(testsupport.CommandRetryTimeout).WithPolling(testsupport.CommandRetryInterval).Should(Succeed())
 
 		cmd := gitsign.Command(testsupport.TestContext, "verify",
 			"--certificate-identity", fmt.Sprintf("%s@%s", api.GetValueFor(api.OidcUser), api.GetValueFor(api.OidcUserDomain)),

--- a/test/testsupport/test_support.go
+++ b/test/testsupport/test_support.go
@@ -25,6 +25,12 @@ const (
 var (
 	TestContext       context.Context
 	TestTimeoutMedium = 5 * time.Minute
+
+	// CommandRetryTimeout is the maximum time to retry transient command
+	// failures (e.g. TUF httpd returning 503 during cosign/gitsign init).
+	CommandRetryTimeout  = 2 * time.Minute
+	CommandRetryInterval = 10 * time.Second
+
 	// Config keys that must be defined for any test.
 	mandatoryAPIConfigKeys = []string{api.TufURL}
 )


### PR DESCRIPTION
## Summary
Wrap TUF init, cosign verify, and gitsign verify calls in retries. Deploy operator with TARGET_PLATFORM=kubernetes on Kind and build from source.

e.g https://github.com/securesign/secure-sign-operator/actions/runs/27817114954/job/82321690801?pr=1940
