### PR TITLE
feat: support Developer Portal ConsoleCLIDownload URLs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -108,6 +108,12 @@ jobs:
           sed -i "s#https://your-oidc-issuer-url#http://${OIDC_HOST}/realms/trusted-artifact-signer#" \
             config/samples/rhtas_v1alpha1_securesign.yaml
           kubectl create ns ${{ env.TEST_NAMESPACE }}
+          echo "Waiting for conversion webhook to be ready..."
+          for i in $(seq 1 60); do
+            kubectl create --dry-run=server -f config/samples/rhtas_v1alpha1_securesign.yaml 2>/dev/null && break
+            echo "Waiting for conversion webhook... ($i/60)"
+            sleep 5
+          done
           kubectl create -f config/samples/rhtas_v1alpha1_securesign.yaml -n ${{ env.TEST_NAMESPACE }}
           sleep 1
           kubectl wait --for=condition=Ready securesign/securesign-sample \

--- a/pkg/kubernetes/cliDownloads.go
+++ b/pkg/kubernetes/cliDownloads.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	consoleV1 "github.com/openshift/api/console/v1"
@@ -22,11 +23,14 @@ func ConsoleCLIDownload(ctx context.Context, c controller.Reader, cli string, os
 		// Match old cli-server format (clients/<os>/<binary>-<arch>.gz)
 		// and new content gateway format (<binary>_<os>_<arch>.tar.gz)
 		matchOS := strings.Contains(link.Href, "/"+os+"/") || strings.Contains(link.Href, "_"+os+"_")
-		matchArch := strings.Contains(link.Href, arch)
+		matchArch := strings.Contains(link.Href, "-"+arch+".") || strings.Contains(link.Href, "_"+arch+".")
 
 		if matchOS && matchArch {
 			target = link.Href
 		}
+	}
+	if target == "" {
+		return "", fmt.Errorf("no download link found for %s on %s/%s", cli, os, arch)
 	}
 	return target, nil
 }

--- a/pkg/kubernetes/cliDownloads.go
+++ b/pkg/kubernetes/cliDownloads.go
@@ -2,7 +2,6 @@ package kubernetes
 
 import (
 	"context"
-	"regexp"
 	"strings"
 
 	consoleV1 "github.com/openshift/api/console/v1"
@@ -20,7 +19,9 @@ func ConsoleCLIDownload(ctx context.Context, c controller.Reader, cli string, os
 	}
 	var target string
 	for _, link := range cld.Spec.Links {
-		matchOS, _ := regexp.MatchString("clients/"+os+"/", link.Href)
+		// Match old cli-server format (clients/<os>/<binary>-<arch>.gz)
+		// and new content gateway format (<binary>_<os>_<arch>.tar.gz)
+		matchOS := strings.Contains(link.Href, "/"+os+"/") || strings.Contains(link.Href, "_"+os+"_")
 		matchArch := strings.Contains(link.Href, arch)
 
 		if matchOS && matchArch {

--- a/pkg/strategy/cgw/cgw.go
+++ b/pkg/strategy/cgw/cgw.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -13,18 +12,6 @@ import (
 	"github.com/securesign/sigstore-e2e/pkg/support"
 	"github.com/sirupsen/logrus"
 )
-
-var cgwNameOverride = map[string]string{
-	"gitsign":   "gitsign_cli",
-	"rekor-cli": "rekor_cli",
-}
-
-func contentGatewayName(name string) string {
-	if override, ok := cgwNameOverride[name]; ok {
-		return override
-	}
-	return strings.ReplaceAll(name, "-", "_")
-}
 
 func init() {
 	strategy.Register("cgw", func() strategy.Strategy {
@@ -39,7 +26,7 @@ func init() {
 }
 
 func download(ctx context.Context, cgwURL string, cliName string) (string, error) {
-	cgwName := contentGatewayName(cliName)
+	cgwName := support.ContentGatewayName(cliName)
 	archiveName := fmt.Sprintf("%s_%s_%s.tar.gz", cgwName, runtime.GOOS, runtime.GOARCH)
 	link := fmt.Sprintf("%s/%s", strings.TrimRight(cgwURL, "/"), archiveName)
 
@@ -54,23 +41,5 @@ func download(ctx context.Context, cgwURL string, cliName string) (string, error
 		return "", err
 	}
 
-	candidates := []string{
-		cliName,
-		fmt.Sprintf("%s_%s_%s", cgwName, runtime.GOOS, runtime.GOARCH),
-		fmt.Sprintf("%s-%s-%s", cliName, runtime.GOOS, runtime.GOARCH),
-	}
-	if runtime.GOOS == "windows" {
-		for i, name := range candidates {
-			candidates[i] = name + ".exe"
-		}
-	}
-
-	for _, name := range candidates {
-		path := filepath.Join(tmp, name)
-		if _, err = os.Stat(path); err == nil {
-			return path, nil
-		}
-	}
-
-	return "", fmt.Errorf("binary for '%s' not found in extracted archive from %s (tried %v)", cliName, link, candidates)
+	return support.FindBinary(tmp, cliName, runtime.GOOS, runtime.GOARCH)
 }

--- a/pkg/strategy/cgw/cgw_test.go
+++ b/pkg/strategy/cgw/cgw_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/securesign/sigstore-e2e/pkg/strategy"
 	"github.com/securesign/sigstore-e2e/pkg/strategy/testutil"
+	"github.com/securesign/sigstore-e2e/pkg/support"
 )
 
 func TestContentGatewayName(t *testing.T) {
@@ -26,9 +27,9 @@ func TestContentGatewayName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			got := contentGatewayName(tt.input)
+			got := support.ContentGatewayName(tt.input)
 			if got != tt.expected {
-				t.Errorf("contentGatewayName(%q) = %q, want %q", tt.input, got, tt.expected)
+				t.Errorf("ContentGatewayName(%q) = %q, want %q", tt.input, got, tt.expected)
 			}
 		})
 	}
@@ -42,7 +43,7 @@ func TestRegistered(t *testing.T) {
 
 func TestStrategy(t *testing.T) {
 	binaryContent := []byte("#!/bin/sh\necho cosign\n")
-	archiveName := fmt.Sprintf("%s_%s_%s.tar.gz", contentGatewayName("cosign"), runtime.GOOS, runtime.GOARCH)
+	archiveName := fmt.Sprintf("%s_%s_%s.tar.gz", support.ContentGatewayName("cosign"), runtime.GOOS, runtime.GOARCH)
 
 	archive := testutil.BuildTarGz(t, map[string][]byte{
 		"cosign": binaryContent,
@@ -61,7 +62,7 @@ func TestStrategy(t *testing.T) {
 
 func TestStrategyNameOverride(t *testing.T) {
 	binaryContent := []byte("#!/bin/sh\necho gitsign\n")
-	cgwName := contentGatewayName("gitsign")
+	cgwName := support.ContentGatewayName("gitsign")
 	archiveName := fmt.Sprintf("%s_%s_%s.tar.gz", cgwName, runtime.GOOS, runtime.GOARCH)
 	binaryName := fmt.Sprintf("%s_%s_%s", cgwName, runtime.GOOS, runtime.GOARCH)
 

--- a/pkg/strategy/openshift/openshift.go
+++ b/pkg/strategy/openshift/openshift.go
@@ -2,9 +2,8 @@ package openshift
 
 import (
 	"context"
-	"fmt"
+	"net/url"
 	"os"
-	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -14,18 +13,6 @@ import (
 	"github.com/sirupsen/logrus"
 	controller "sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-var cgwNameOverride = map[string]string{
-	"gitsign":   "gitsign_cli",
-	"rekor-cli": "rekor_cli",
-}
-
-func contentGatewayName(name string) string {
-	if override, ok := cgwNameOverride[name]; ok {
-		return override
-	}
-	return strings.ReplaceAll(name, "-", "_")
-}
 
 func init() {
 	strategy.Register("openshift", func() strategy.Strategy {
@@ -42,10 +29,18 @@ func download(ctx context.Context, client controller.Reader, cliName string) (st
 		return "", err
 	}
 
-	if strings.HasSuffix(link, ".tar.gz") {
+	if isTarGz(link) {
 		return downloadTarGz(ctx, cliName, link)
 	}
 	return strategy.DownloadFromLink(ctx, cliName, link)
+}
+
+func isTarGz(link string) bool {
+	u, err := url.Parse(link)
+	if err != nil {
+		return strings.HasSuffix(link, ".tar.gz")
+	}
+	return strings.HasSuffix(u.Path, ".tar.gz")
 }
 
 func downloadTarGz(ctx context.Context, cliName string, link string) (string, error) {
@@ -60,24 +55,5 @@ func downloadTarGz(ctx context.Context, cliName string, link string) (string, er
 		return "", err
 	}
 
-	cgwName := contentGatewayName(cliName)
-	candidates := []string{
-		cliName,
-		fmt.Sprintf("%s_%s_%s", cgwName, runtime.GOOS, runtime.GOARCH),
-		fmt.Sprintf("%s-%s-%s", cliName, runtime.GOOS, runtime.GOARCH),
-	}
-	if runtime.GOOS == "windows" {
-		for i, name := range candidates {
-			candidates[i] = name + ".exe"
-		}
-	}
-
-	for _, name := range candidates {
-		path := filepath.Join(tmp, name)
-		if _, err = os.Stat(path); err == nil {
-			return path, nil
-		}
-	}
-
-	return "", fmt.Errorf("binary for '%s' not found in extracted archive from %s (tried %v)", cliName, link, candidates)
+	return support.FindBinary(tmp, cliName, runtime.GOOS, runtime.GOARCH)
 }

--- a/pkg/strategy/openshift/openshift.go
+++ b/pkg/strategy/openshift/openshift.go
@@ -2,13 +2,30 @@ package openshift
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/securesign/sigstore-e2e/pkg/kubernetes"
 	"github.com/securesign/sigstore-e2e/pkg/strategy"
+	"github.com/securesign/sigstore-e2e/pkg/support"
 	"github.com/sirupsen/logrus"
 	controller "sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+var cgwNameOverride = map[string]string{
+	"gitsign":   "gitsign_cli",
+	"rekor-cli": "rekor_cli",
+}
+
+func contentGatewayName(name string) string {
+	if override, ok := cgwNameOverride[name]; ok {
+		return override
+	}
+	return strings.ReplaceAll(name, "-", "_")
+}
 
 func init() {
 	strategy.Register("openshift", func() strategy.Strategy {
@@ -24,5 +41,43 @@ func download(ctx context.Context, client controller.Reader, cliName string) (st
 	if err != nil {
 		return "", err
 	}
+
+	if strings.HasSuffix(link, ".tar.gz") {
+		return downloadTarGz(ctx, cliName, link)
+	}
 	return strategy.DownloadFromLink(ctx, cliName, link)
+}
+
+func downloadTarGz(ctx context.Context, cliName string, link string) (string, error) {
+	logrus.Info("Downloading ", cliName, " from ", link)
+
+	tmp, err := os.MkdirTemp("", cliName)
+	if err != nil {
+		return "", err
+	}
+
+	if err = support.DownloadAndUntarArchive(ctx, link, tmp); err != nil {
+		return "", err
+	}
+
+	cgwName := contentGatewayName(cliName)
+	candidates := []string{
+		cliName,
+		fmt.Sprintf("%s_%s_%s", cgwName, runtime.GOOS, runtime.GOARCH),
+		fmt.Sprintf("%s-%s-%s", cliName, runtime.GOOS, runtime.GOARCH),
+	}
+	if runtime.GOOS == "windows" {
+		for i, name := range candidates {
+			candidates[i] = name + ".exe"
+		}
+	}
+
+	for _, name := range candidates {
+		path := filepath.Join(tmp, name)
+		if _, err = os.Stat(path); err == nil {
+			return path, nil
+		}
+	}
+
+	return "", fmt.Errorf("binary for '%s' not found in extracted archive from %s (tried %v)", cliName, link, candidates)
 }

--- a/pkg/strategy/openshift/openshift_test.go
+++ b/pkg/strategy/openshift/openshift_test.go
@@ -68,7 +68,7 @@ func TestStrategyContentGateway(t *testing.T) {
 	binaryContent := []byte("#!/bin/sh\necho testcli\n")
 	binaryName := "testcli_" + runtime.GOOS + "_" + runtime.GOARCH
 	tarGz := testutil.BuildTarGz(t, map[string][]byte{binaryName: binaryContent})
-	expectedPath := "/cgw/RHTAS/1.4.0/testcli_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz"
+	expectedPath := "/RHTAS/1.4.1/testcli_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz"
 
 	srv := testutil.ServeBinary(t, expectedPath, tarGz)
 
@@ -78,11 +78,11 @@ func TestStrategyContentGateway(t *testing.T) {
 			DisplayName: "testcli - Command Line Interface (CLI)",
 			Description: "test binary",
 			Links: []consoleV1.CLIDownloadLink{
-				{Text: "Download testcli for Linux x86_64", Href: srv.URL + "/cgw/RHTAS/1.4.0/testcli_linux_amd64.tar.gz"},
-				{Text: "Download testcli for Linux arm64", Href: srv.URL + "/cgw/RHTAS/1.4.0/testcli_linux_arm64.tar.gz"},
-				{Text: "Download testcli for Mac x86_64", Href: srv.URL + "/cgw/RHTAS/1.4.0/testcli_darwin_amd64.tar.gz"},
-				{Text: "Download testcli for Mac arm64", Href: srv.URL + "/cgw/RHTAS/1.4.0/testcli_darwin_arm64.tar.gz"},
-				{Text: "Download testcli for Windows x86_64", Href: srv.URL + "/cgw/RHTAS/1.4.0/testcli_windows_amd64.zip"},
+				{Text: "Download testcli for Linux x86_64", Href: srv.URL + "/RHTAS/1.4.1/testcli_linux_amd64.tar.gz"},
+				{Text: "Download testcli for Linux arm64", Href: srv.URL + "/RHTAS/1.4.1/testcli_linux_arm64.tar.gz"},
+				{Text: "Download testcli for Mac x86_64", Href: srv.URL + "/RHTAS/1.4.1/testcli_darwin_amd64.tar.gz"},
+				{Text: "Download testcli for Mac arm64", Href: srv.URL + "/RHTAS/1.4.1/testcli_darwin_arm64.tar.gz"},
+				{Text: "Download testcli for Windows x86_64", Href: srv.URL + "/RHTAS/1.4.1/testcli_windows_amd64.zip"},
 			},
 		},
 	}
@@ -102,7 +102,7 @@ func TestStrategyContentGatewayNameOverride(t *testing.T) {
 	binaryContent := []byte("#!/bin/sh\necho gitsign\n")
 	binaryName := "gitsign_cli_" + runtime.GOOS + "_" + runtime.GOARCH
 	tarGz := testutil.BuildTarGz(t, map[string][]byte{binaryName: binaryContent})
-	expectedPath := "/cgw/RHTAS/1.4.0/gitsign_cli_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz"
+	expectedPath := "/RHTAS/1.4.1/gitsign_cli_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz"
 
 	srv := testutil.ServeBinary(t, expectedPath, tarGz)
 
@@ -112,11 +112,11 @@ func TestStrategyContentGatewayNameOverride(t *testing.T) {
 			DisplayName: "gitsign - Command Line Interface (CLI)",
 			Description: "gitsign is a CLI tool that allows you to digitally sign and verify git commits.",
 			Links: []consoleV1.CLIDownloadLink{
-				{Text: "Download gitsign for Linux x86_64", Href: srv.URL + "/cgw/RHTAS/1.4.0/gitsign_cli_linux_amd64.tar.gz"},
-				{Text: "Download gitsign for Linux arm64", Href: srv.URL + "/cgw/RHTAS/1.4.0/gitsign_cli_linux_arm64.tar.gz"},
-				{Text: "Download gitsign for Mac x86_64", Href: srv.URL + "/cgw/RHTAS/1.4.0/gitsign_cli_darwin_amd64.tar.gz"},
-				{Text: "Download gitsign for Mac arm64", Href: srv.URL + "/cgw/RHTAS/1.4.0/gitsign_cli_darwin_arm64.tar.gz"},
-				{Text: "Download gitsign for Windows x86_64", Href: srv.URL + "/cgw/RHTAS/1.4.0/gitsign_cli_windows_amd64.zip"},
+				{Text: "Download gitsign for Linux x86_64", Href: srv.URL + "/RHTAS/1.4.1/gitsign_cli_linux_amd64.tar.gz"},
+				{Text: "Download gitsign for Linux arm64", Href: srv.URL + "/RHTAS/1.4.1/gitsign_cli_linux_arm64.tar.gz"},
+				{Text: "Download gitsign for Mac x86_64", Href: srv.URL + "/RHTAS/1.4.1/gitsign_cli_darwin_amd64.tar.gz"},
+				{Text: "Download gitsign for Mac arm64", Href: srv.URL + "/RHTAS/1.4.1/gitsign_cli_darwin_arm64.tar.gz"},
+				{Text: "Download gitsign for Windows x86_64", Href: srv.URL + "/RHTAS/1.4.1/gitsign_cli_windows_amd64.zip"},
 			},
 		},
 	}

--- a/pkg/strategy/openshift/openshift_test.go
+++ b/pkg/strategy/openshift/openshift_test.go
@@ -132,11 +132,32 @@ func TestStrategyContentGatewayNameOverride(t *testing.T) {
 	t.Logf("OK: gitsign -> %s", path)
 }
 
-func TestStrategyError(t *testing.T) {
+func TestStrategyErrorNotFound(t *testing.T) {
 	fakeClient := newFakeClient(t).Build()
 
 	_, err := download(t.Context(), fakeClient, "nonexistent")
 	if err == nil {
 		t.Fatal("expected error for nonexistent CLI download")
 	}
+}
+
+func TestStrategyErrorNoMatchingLink(t *testing.T) {
+	cliDownload := consoleV1.ConsoleCLIDownload{
+		ObjectMeta: metav1.ObjectMeta{Name: "testcli"},
+		Spec: consoleV1.ConsoleCLIDownloadSpec{
+			DisplayName: "Test CLI",
+			Description: "test binary",
+			Links: []consoleV1.CLIDownloadLink{
+				{Text: "Download for SomeOtherOS", Href: "https://example.com/testcli_fakeos_fakearch.tar.gz"},
+			},
+		},
+	}
+
+	fakeClient := newFakeClient(t, cliDownload).Build()
+
+	_, err := download(t.Context(), fakeClient, "testcli")
+	if err == nil {
+		t.Fatal("expected error when no link matches the current OS/arch")
+	}
+	t.Logf("OK: got expected error: %v", err)
 }

--- a/pkg/strategy/openshift/openshift_test.go
+++ b/pkg/strategy/openshift/openshift_test.go
@@ -31,7 +31,7 @@ func TestRegistered(t *testing.T) {
 	}
 }
 
-func TestStrategy(t *testing.T) {
+func TestStrategyCliServer(t *testing.T) {
 	binaryContent := []byte("#!/bin/sh\necho testcli\n")
 	gzipped := testutil.GzipBytes(t, binaryContent)
 	expectedPath := "/clients/" + runtime.GOOS + "/testcli-" + runtime.GOARCH + ".gz"
@@ -62,6 +62,74 @@ func TestStrategy(t *testing.T) {
 
 	testutil.VerifyBinary(t, path, binaryContent)
 	t.Logf("OK: testcli -> %s", path)
+}
+
+func TestStrategyContentGateway(t *testing.T) {
+	binaryContent := []byte("#!/bin/sh\necho testcli\n")
+	binaryName := "testcli_" + runtime.GOOS + "_" + runtime.GOARCH
+	tarGz := testutil.BuildTarGz(t, map[string][]byte{binaryName: binaryContent})
+	expectedPath := "/cgw/RHTAS/1.4.0/testcli_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz"
+
+	srv := testutil.ServeBinary(t, expectedPath, tarGz)
+
+	cliDownload := consoleV1.ConsoleCLIDownload{
+		ObjectMeta: metav1.ObjectMeta{Name: "testcli"},
+		Spec: consoleV1.ConsoleCLIDownloadSpec{
+			DisplayName: "testcli - Command Line Interface (CLI)",
+			Description: "test binary",
+			Links: []consoleV1.CLIDownloadLink{
+				{Text: "Download testcli for Linux x86_64", Href: srv.URL + "/cgw/RHTAS/1.4.0/testcli_linux_amd64.tar.gz"},
+				{Text: "Download testcli for Linux arm64", Href: srv.URL + "/cgw/RHTAS/1.4.0/testcli_linux_arm64.tar.gz"},
+				{Text: "Download testcli for Mac x86_64", Href: srv.URL + "/cgw/RHTAS/1.4.0/testcli_darwin_amd64.tar.gz"},
+				{Text: "Download testcli for Mac arm64", Href: srv.URL + "/cgw/RHTAS/1.4.0/testcli_darwin_arm64.tar.gz"},
+				{Text: "Download testcli for Windows x86_64", Href: srv.URL + "/cgw/RHTAS/1.4.0/testcli_windows_amd64.zip"},
+			},
+		},
+	}
+
+	fakeClient := newFakeClient(t, cliDownload).Build()
+
+	path, err := download(t.Context(), fakeClient, "testcli")
+	if err != nil {
+		t.Fatalf("download failed: %v", err)
+	}
+
+	testutil.VerifyBinary(t, path, binaryContent)
+	t.Logf("OK: testcli -> %s", path)
+}
+
+func TestStrategyContentGatewayNameOverride(t *testing.T) {
+	binaryContent := []byte("#!/bin/sh\necho gitsign\n")
+	binaryName := "gitsign_cli_" + runtime.GOOS + "_" + runtime.GOARCH
+	tarGz := testutil.BuildTarGz(t, map[string][]byte{binaryName: binaryContent})
+	expectedPath := "/cgw/RHTAS/1.4.0/gitsign_cli_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz"
+
+	srv := testutil.ServeBinary(t, expectedPath, tarGz)
+
+	cliDownload := consoleV1.ConsoleCLIDownload{
+		ObjectMeta: metav1.ObjectMeta{Name: "gitsign"},
+		Spec: consoleV1.ConsoleCLIDownloadSpec{
+			DisplayName: "gitsign - Command Line Interface (CLI)",
+			Description: "gitsign is a CLI tool that allows you to digitally sign and verify git commits.",
+			Links: []consoleV1.CLIDownloadLink{
+				{Text: "Download gitsign for Linux x86_64", Href: srv.URL + "/cgw/RHTAS/1.4.0/gitsign_cli_linux_amd64.tar.gz"},
+				{Text: "Download gitsign for Linux arm64", Href: srv.URL + "/cgw/RHTAS/1.4.0/gitsign_cli_linux_arm64.tar.gz"},
+				{Text: "Download gitsign for Mac x86_64", Href: srv.URL + "/cgw/RHTAS/1.4.0/gitsign_cli_darwin_amd64.tar.gz"},
+				{Text: "Download gitsign for Mac arm64", Href: srv.URL + "/cgw/RHTAS/1.4.0/gitsign_cli_darwin_arm64.tar.gz"},
+				{Text: "Download gitsign for Windows x86_64", Href: srv.URL + "/cgw/RHTAS/1.4.0/gitsign_cli_windows_amd64.zip"},
+			},
+		},
+	}
+
+	fakeClient := newFakeClient(t, cliDownload).Build()
+
+	path, err := download(t.Context(), fakeClient, "gitsign")
+	if err != nil {
+		t.Fatalf("download failed: %v", err)
+	}
+
+	testutil.VerifyBinary(t, path, binaryContent)
+	t.Logf("OK: gitsign -> %s", path)
 }
 
 func TestStrategyError(t *testing.T) {

--- a/pkg/support/cgw.go
+++ b/pkg/support/cgw.go
@@ -1,0 +1,45 @@
+package support
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var cgwNameOverride = map[string]string{
+	"gitsign":   "gitsign_cli",
+	"rekor-cli": "rekor_cli",
+}
+
+// ContentGatewayName maps a CLI tool name to its content gateway archive name.
+func ContentGatewayName(name string) string {
+	if override, ok := cgwNameOverride[name]; ok {
+		return override
+	}
+	return strings.ReplaceAll(name, "-", "_")
+}
+
+// FindBinary searches for a CLI binary in the given directory using candidate name patterns.
+func FindBinary(dir, cliName, goos, goarch string) (string, error) {
+	cgwName := ContentGatewayName(cliName)
+	candidates := []string{
+		cliName,
+		fmt.Sprintf("%s_%s_%s", cgwName, goos, goarch),
+		fmt.Sprintf("%s-%s-%s", cliName, goos, goarch),
+	}
+	if goos == "windows" {
+		for i, name := range candidates {
+			candidates[i] = name + ".exe"
+		}
+	}
+
+	for _, name := range candidates {
+		path := filepath.Join(dir, name)
+		if _, err := os.Stat(path); err == nil {
+			return path, nil
+		}
+	}
+
+	return "", fmt.Errorf("binary for '%s' not found in extracted archive (tried %v)", cliName, candidates)
+}

--- a/pkg/support/testSupport.go
+++ b/pkg/support/testSupport.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/docker/docker/api/types/registry"
@@ -65,11 +66,8 @@ func DownloadAndUnzip(ctx context.Context, link string, writer io.Writer) error 
 	pr, pw := io.Pipe()
 
 	go func() {
-		defer pw.Close()
-		if _, err := Download(ctx, link, pw); err != nil {
-			panic(err)
-		}
-
+		_, err := Download(ctx, link, pw)
+		pw.CloseWithError(err)
 	}()
 	return Gunzip(pr, writer)
 }
@@ -78,30 +76,47 @@ func DownloadAndUntarArchive(ctx context.Context, link string, dst string) error
 	pr, pw := io.Pipe()
 
 	go func() {
-		defer pw.Close()
-		if _, err := Download(ctx, link, pw); err != nil {
-			panic(err)
-		}
+		_, err := Download(ctx, link, pw)
+		pw.CloseWithError(err)
 	}()
 	return UntarArchive(dst, pr)
 }
 
 func Download(ctx context.Context, link string, writer io.Writer) (int64, error) {
 	client := &http.Client{Timeout: 2 * time.Minute} //nolint:mnd
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, link, nil)
-	if err != nil {
-		return 0, err
-	}
-	resp, err := client.Do(req)
-	if err != nil {
-		return 0, err
-	}
 
-	if resp.StatusCode != http.StatusOK {
-		return 0, fmt.Errorf("bad status: %s", resp.Status)
+	const maxRetries = 5
+	var lastErr error
+	for attempt := range maxRetries {
+		if attempt > 0 {
+			delay := time.Duration(1<<uint(attempt-1)) * time.Second
+			logrus.Infof("Retrying download (%d/%d) after %v: %s", attempt+1, maxRetries, delay, link)
+			select {
+			case <-ctx.Done():
+				return 0, ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, link, nil)
+		if err != nil {
+			return 0, err
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			lastErr = fmt.Errorf("bad status: %s", resp.Status)
+			continue
+		}
+		defer resp.Body.Close()
+		return io.Copy(writer, resp.Body)
 	}
-	defer resp.Body.Close()
-	return io.Copy(writer, resp.Body)
+	return 0, fmt.Errorf("download failed after %d attempts: %w", maxRetries, lastErr)
 }
 
 func Gunzip(reader io.Reader, writer io.Writer) error {
@@ -155,8 +170,11 @@ func UntarArchive(dst string, r io.Reader) error {
 			continue
 		}
 
-		// the target location where the dir/file should be created
-		target := filepath.Join(dst, header.Name) // #nosec G305 - We don't expect file traversal attack on test ENV
+		clean := filepath.Clean(header.Name)
+		if filepath.IsAbs(clean) || strings.HasPrefix(clean, ".."+string(os.PathSeparator)) || clean == ".." {
+			return fmt.Errorf("tar entry %q contains path traversal", header.Name)
+		}
+		target := filepath.Join(dst, clean) // #nosec G305
 
 		// check the file type
 		switch header.Typeflag {


### PR DESCRIPTION
## Summary

- Update `cliDownloads.go` URL matching to support both old cli-server (`/clients/<os>/`) and new Developer Portal (`_<os>_<arch>`) URL formats
- Add `.tar.gz` archive handling to the openshift strategy with binary name resolution (including `cgwNameOverride` for `gitsign` → `gitsign_cli`)
- Fully backward-compatible: older operator versions using cli-server `.gz` URLs continue to work via the existing `DownloadFromLink` path

Companion to [securesign/secure-sign-operator#1988](https://github.com/securesign/secure-sign-operator/pull/1988) which moves ConsoleCLIDownload management from the operator controller to static OLM manifests pointing to the Red Hat Developer Portal.

Implements [SECURESIGN-2158](https://redhat.atlassian.net/browse/SECURESIGN-2158)

## Backward compatibility

| Operator version | URL format | Behavior |
|---|---|---|
| 1.3.x, 1.4.x (old) | `https://<cli-server>/clients/linux/cosign-amd64.gz` | Matches via `/linux/`, downloads via `DownloadFromLink` (plain .gz) — **unchanged** |
| 1.5.0+ (new) | `https://developers.redhat.com/.../cosign_linux_amd64.tar.gz` | Matches via `_linux_`, downloads via `downloadTarGz` (tar.gz extraction) — **new path** |

## Test plan

- [x] `TestStrategyCliServer` — old cli-server format still works
- [x] `TestStrategyContentGateway` — new content gateway format works
- [x] `TestStrategyContentGatewayNameOverride` — gitsign → gitsign_cli name mapping works
- [x] `TestStrategyError` — nonexistent CR returns error
- [x] All `go test ./pkg/...` pass

[SECURESIGN-2158]: https://redhat.atlassian.net/browse/SECURESIGN-2158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ