### PR TITLE
fix: migrate playwright-go to mxschmitt/playwright-go v0.6100.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,11 +9,11 @@ require (
 	github.com/go-git/go-git/v5 v5.9.0
 	github.com/google/go-containerregistry v0.20.2
 	github.com/google/uuid v1.6.0
+	github.com/mxschmitt/playwright-go v0.6100.0
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.10
 	github.com/opencontainers/image-spec v1.1.0
 	github.com/openshift/api v0.0.0-20230817133225-564be9ddb58e
-	github.com/playwright-community/playwright-go v0.6000.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/viper v1.17.0
 	github.com/testcontainers/testcontainers-go/modules/registry v0.33.0

--- a/go.sum
+++ b/go.sum
@@ -322,6 +322,8 @@ github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/mxschmitt/playwright-go v0.6100.0 h1:HYNnbGZsTHz8veJyDGe4fU1iPxfvXqzmwKchzuvGCsY=
+github.com/mxschmitt/playwright-go v0.6100.0/go.mod h1:A7VtrS3j/c8ToGnSVUaOfNtQQVxi6JotUS0jeuus6r4=
 github.com/onsi/ginkgo/v2 v2.11.0 h1:WgqUCUt/lT6yXoQ8Wef0fsNn5cAuMK7+KT9UFRz2tcU=
 github.com/onsi/ginkgo/v2 v2.11.0/go.mod h1:ZhrRA5XmEE3x3rhlzamx/JJvujdZoJ2uvgI7kR0iZvM=
 github.com/onsi/gomega v1.27.10 h1:naR28SdDFlqrG6kScpT8VWpu1xWY5nJRCF3XaYyBjhI=
@@ -340,8 +342,6 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
-github.com/playwright-community/playwright-go v0.6000.0 h1:R7sENcRI6n0Zd5ZoW8EKdVF1ZVJgvTubfJeqKHNGvsw=
-github.com/playwright-community/playwright-go v0.6000.0/go.mod h1:z/YpFVdU4LAi+0f9VPOCkGvmdH6dCrtza9nxnXFXgiE=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -39,7 +39,7 @@ test:
 
 setup:
 	@echo "Installing Playwright dependencies..."
-	@go run github.com/playwright-community/playwright-go/cmd/playwright install
+	@go run github.com/mxschmitt/playwright-go/cmd/playwright install
 
 
 .PHONY: build test setup all 

--- a/test/rekorsearchui/rekor_search_sign_verify_test.go
+++ b/test/rekorsearchui/rekor_search_sign_verify_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/playwright-community/playwright-go"
+	"github.com/mxschmitt/playwright-go"
 	"github.com/securesign/sigstore-e2e/pkg/api"
 	"github.com/securesign/sigstore-e2e/pkg/clients"
 	"github.com/securesign/sigstore-e2e/test/testsupport"


### PR DESCRIPTION
## Summary

- Migrate from deprecated `playwright-community/playwright-go` to `mxschmitt/playwright-go` v0.6100.0
- The Playwright `/builds/driver` CDN (azureedge) has been shut down by Microsoft — driver archives were progressively deleted, causing 404 errors on macOS and Windows during `playwright install`
- v0.6100.0 assembles the driver from npm (`playwright-core`) + nodejs.org (Node.js binary) instead of the deprecated CDN ([PR #615](https://github.com/playwright-community/playwright-go/pull/615))

### Changes
- `go.mod` — `playwright-community/playwright-go v0.6000.0` → `mxschmitt/playwright-go v0.6100.0`
- `test/rekorsearchui/rekor_search_sign_verify_test.go` — updated import path
- `scripts/Makefile` — updated `go run` install command

### Other repos that also need updating
Tracked in [SECURESIGN-4984](https://redhat.atlassian.net/browse/SECURESIGN-4984):
- `pipelines` — `tasks/integration-test/sigstore-e2e.yaml:152`
- `secure-sign-operator` — `.github/workflows/main.yml:674`
- `releases` — `.github/workflows/cross-platform-tests.yml:442`
- `sigstore-e2e` (main branch) — `.github/workflows/e2e.yml:134`

### References
- CDN deprecation: [playwright-go#593](https://github.com/playwright-community/playwright-go/issues/593)
- Fix PR: [playwright-go#615](https://github.com/playwright-community/playwright-go/pull/615)
- Release: [v0.6100.0](https://github.com/playwright-community/playwright-go/releases/tag/v0.6100.0)

## Test plan
- [x] Verify `go run github.com/mxschmitt/playwright-go/cmd/playwright@v0.6100.0 install --with-deps` works on macOS, Windows, Linux
- [x] Run cross-platform-tests workflow against a cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SECURESIGN-4984]: https://redhat.atlassian.net/browse/SECURESIGN-4984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ