### PR TITLE
feat: fall back to staging Developer Portal for pre-release downloads

### DIFF
--- a/pkg/strategy/openshift/openshift.go
+++ b/pkg/strategy/openshift/openshift.go
@@ -22,6 +22,11 @@ func init() {
 	})
 }
 
+const (
+	prodHost    = "developers.redhat.com"
+	stagingHost = "developers.qa.redhat.com"
+)
+
 func download(ctx context.Context, client controller.Reader, cliName string) (string, error) {
 	logrus.Info("Getting binary '", cliName, "' from Openshift")
 	link, err := kubernetes.ConsoleCLIDownload(ctx, client, cliName, runtime.GOOS, runtime.GOARCH)
@@ -30,7 +35,13 @@ func download(ctx context.Context, client controller.Reader, cliName string) (st
 	}
 
 	if isTarGz(link) {
-		return downloadTarGz(ctx, cliName, link)
+		path, err := downloadTarGz(ctx, cliName, link)
+		if err != nil && strings.Contains(link, prodHost) {
+			stagingLink := strings.Replace(link, prodHost, stagingHost, 1)
+			logrus.Infof("Production download failed, falling back to staging: %s", stagingLink)
+			return downloadTarGz(ctx, cliName, stagingLink)
+		}
+		return path, err
 	}
 	return strategy.DownloadFromLink(ctx, cliName, link)
 }


### PR DESCRIPTION
## Summary

- When the `openshift` strategy downloads a CLI binary from a ConsoleCLIDownload CR pointing to `developers.redhat.com` and the download fails (e.g., pre-release binaries not yet published), automatically retry on the staging portal (`developers.qa.redhat.com`)
- Only Developer Portal URLs are rewritten — cli-server URLs are unaffected
- Enables pre-release E2E testing without requiring production binary publication

## How it works

The operator's ConsoleCLIDownload manifests always point to **production** `developers.redhat.com` (correct for end users). During pre-release testing, version X.Y.Z binaries may not be published to prod yet. This fallback retries on staging where RC binaries are available earlier.

```
openshift strategy → reads CR → tries prod URL → 400/404 → rewrites to staging → succeeds
```

Companion to [securesign/secure-sign-operator#1988](https://github.com/securesign/secure-sign-operator/pull/1988)

Implements [SECURESIGN-2158](https://redhat.atlassian.net/browse/SECURESIGN-2158)

## Test plan

- [x] All `go test ./pkg/...` pass
- [x] `TestStrategyCliServer` — cli-server format unaffected by fallback
- [x] `TestStrategyContentGateway` — content gateway format works
- [ ] E2E with 1.5.0 operator + staging binaries

[SECURESIGN-2158]: https://redhat.atlassian.net/browse/SECURESIGN-2158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ