### PR TITLE
ci: add CI workflow for release-1.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  pull_request:
+    branches: ["main", "release*"]
+  push:
+    branches: ["main", "release*"]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.64.8
+          args: --verbose --timeout=15m
+
+  unit-test:
+    name: Unit tests
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build
+        run: go build ./...
+
+      - name: Run strategy tests
+        run: go test ./pkg/... -v -count=1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,7 @@
 linters-settings:
+  gosec:
+    excludes:
+      - G115
   lll:
     line-length: 170
 linters:
@@ -8,6 +11,7 @@ linters:
     - deadcode
     - depguard
     - dupl
+    - errname
     - exhaustive
     - exhaustivestruct
     - exhaustruct
@@ -26,6 +30,7 @@ linters:
     - gomnd
     - gomoddirectives
     - ifshort
+    - intrange
     - interfacer
     - ireturn
     - lll
@@ -37,6 +42,7 @@ linters:
     - nolintlint
     - nosnakecase
     - paralleltest
+    - perfsprint
     - revive
     - rowserrcheck
     - scopelint


### PR DESCRIPTION
## Summary
Backport `ci.yml` (lint + unit tests) from main so that PRs targeting release branches get CI coverage. Without this, PRs merged with no checks (as seen with PR #84).

**Changes from main:**
- `ci.yml`: golangci-lint pinned to v1.64.8 (release branches use v1 config format)
- `.golangci.yml`: disable `errname`, `intrange`, `perfsprint` and exclude gosec G115 (not enabled on main v2 config either)

**Note:** `e2e.yml` not included — the operator on `release-1.3` fails to start in Kind with `no matches for kind "Ingress" in version "config.openshift.io/v1"` (requires OpenShift-specific CRDs not available in Kind).

## Test plan
- [x] CI workflow self-triggers on this PR
- [x] Lint passes with v1 config
- [x] Unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)