### PR TITLE
fix: use scoped squid proxy for staging Developer Portal downloads

### DIFF
--- a/pkg/support/testSupport.go
+++ b/pkg/support/testSupport.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -82,8 +83,30 @@ func DownloadAndUntarArchive(ctx context.Context, link string, dst string) error
 	return UntarArchive(dst, pr)
 }
 
+const squidProxy = "http://squid.corp.redhat.com:3128"
+
+var stagingProxySuffixes = []string{
+	".qa.redhat.com",
+	".dev.redhat.com",
+	".stage.redhat.com",
+	".preprod.redhat.com",
+}
+
+func proxyForStagingOnly(req *http.Request) (*url.URL, error) {
+	host := req.URL.Hostname()
+	for _, suffix := range stagingProxySuffixes {
+		if strings.HasSuffix(host, suffix) {
+			return url.Parse(squidProxy)
+		}
+	}
+	return nil, nil
+}
+
 func Download(ctx context.Context, link string, writer io.Writer) (int64, error) {
-	client := &http.Client{Timeout: 2 * time.Minute} //nolint:mnd
+	client := &http.Client{
+		Timeout:   2 * time.Minute, //nolint:mnd
+		Transport: &http.Transport{Proxy: proxyForStagingOnly},
+	}
 
 	const maxRetries = 5
 	var lastErr error


### PR DESCRIPTION
## Summary

- Configure a custom HTTP transport proxy in `support.Download()` that routes only Red Hat staging domains (`*.qa.redhat.com`, `*.stage.redhat.com`, `*.dev.redhat.com`, `*.preprod.redhat.com`) through `squid.corp.redhat.com:3128`
- All other traffic (production, cluster-internal, test servers) goes direct — no global `HTTPS_PROXY` needed
- Handles the staging portal's redirect chain: `developers.qa.redhat.com` → `access.cdn.stage.redhat.com`

## Context

The operator's ConsoleCLIDownload manifests point to production `developers.redhat.com`. During pre-release testing, the openshift strategy falls back to staging (`developers.qa.redhat.com`), which is behind a preprod lockdown requiring the corporate squid proxy. This change embeds the proxy routing in the download function following the Red Hat PAC file rules (`hdn.corp.redhat.com/proxy.pac`).

## Verified locally

```
$ go run test_proxy.go
Testing support.Download: https://developers.qa.redhat.com/.../RHTAS/1.5.0/cosign_linux_amd64.tar.gz
OK: 28695814 bytes
```

Implements [SECURESIGN-2158](https://redhat.atlassian.net/browse/SECURESIGN-2158)

[SECURESIGN-2158]: https://redhat.atlassian.net/browse/SECURESIGN-2158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ