### PR TITLE
feat: add CDN fallback for CLI binary downloads

### DIFF
--- a/pkg/strategy/openshift/openshift.go
+++ b/pkg/strategy/openshift/openshift.go
@@ -2,8 +2,10 @@ package openshift
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"os"
+	"regexp"
 	"runtime"
 	"strings"
 
@@ -23,9 +25,12 @@ func init() {
 }
 
 const (
-	prodHost    = "developers.redhat.com"
-	stagingHost = "developers.qa.redhat.com"
+	prodHost        = "developers.redhat.com"
+	stagingHost     = "developers.qa.redhat.com"
+	fallbackVersion = "1.4.1"
 )
+
+var versionRegexp = regexp.MustCompile(`/RHTAS/[^/]+/`)
 
 func download(ctx context.Context, client controller.Reader, cliName string) (string, error) {
 	logrus.Info("Getting binary '", cliName, "' from Openshift")
@@ -39,7 +44,18 @@ func download(ctx context.Context, client controller.Reader, cliName string) (st
 		if err != nil && strings.Contains(link, prodHost) {
 			stagingLink := strings.Replace(link, prodHost, stagingHost, 1)
 			logrus.Infof("Production download failed, falling back to staging: %s", stagingLink)
-			return downloadTarGz(ctx, cliName, stagingLink)
+			path, err = downloadTarGz(ctx, cliName, stagingLink)
+			if err != nil {
+				fallbackLink := versionRegexp.ReplaceAllString(link, "/RHTAS/"+fallbackVersion+"/")
+				logrus.Infof("Staging download failed, falling back to stable %s via CDN: %s", fallbackVersion, fallbackLink)
+				cdnLink, cdnErr := support.ResolveCDNLink(ctx, fallbackLink)
+				if cdnErr != nil {
+					return "", fmt.Errorf("all download attempts failed (prod, staging, CDN fallback): %w", cdnErr)
+				}
+				logrus.Infof("Resolved CDN link: %s", cdnLink)
+				return downloadTarGz(ctx, cliName, cdnLink)
+			}
+			return path, nil
 		}
 		return path, err
 	}

--- a/pkg/support/testSupport.go
+++ b/pkg/support/testSupport.go
@@ -142,6 +142,38 @@ func Download(ctx context.Context, link string, writer io.Writer) (int64, error)
 	return 0, fmt.Errorf("download failed after %d attempts: %w", maxRetries, lastErr)
 }
 
+func ResolveCDNLink(ctx context.Context, link string) (string, error) {
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, link, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusFound && resp.StatusCode != http.StatusMovedPermanently {
+		return "", fmt.Errorf("expected redirect, got %s", resp.Status)
+	}
+	location := resp.Header.Get("Location")
+	parsed, err := url.Parse(location)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse redirect location: %w", err)
+	}
+	cdnURL := parsed.Query().Get("tcDownloadURL")
+	if cdnURL == "" {
+		return "", fmt.Errorf("tcDownloadURL not found in redirect location")
+	}
+	return cdnURL, nil
+}
+
 func Gunzip(reader io.Reader, writer io.Writer) error {
 	gzreader, err := gzip.NewReader(reader)
 	if err != nil {


### PR DESCRIPTION
## Summary

Add a three-tier fallback chain to the openshift strategy for downloading CLI binaries from ConsoleCLIDownload URLs:

| Tier | Source | When it works |
|---|---|---|
| 1. Production | `developers.redhat.com/.../RHTAS/<version>/...` | Post-release (binaries published) |
| 2. Staging | `developers.qa.redhat.com/...` via squid proxy | Pre-release from corporate network |
| 3. CDN fallback | `access.cdn.redhat.com/...` resolved from prod 1.4.1 | Always (stable published version) |

The CDN fallback resolves the direct download URL from the Developer Portal's 302 redirect (`tcDownloadURL` query parameter), bypassing the HTML interstitial page that blocks programmatic downloads.

## Changes

- `pkg/strategy/openshift/openshift.go` — three-tier fallback chain with version regex replacement and CDN resolution
- `pkg/support/testSupport.go` — add `ResolveCDNLink` helper that extracts CDN URL from Developer Portal redirects

## Verified locally against live cluster

```
--- Step 1: Production 1.5.0 ---
  Result: 400 Bad Request (not published)

--- Step 2: Staging (simulated unreachable) ---
  Result: DNS failure (no corporate network)

--- Step 3: CDN fallback (prod 1.4.1) ---
  CDN link: https://access.cdn.redhat.com/.../cosign_linux_amd64.tar.gz?_auth_=...
  PASS: binary at /tmp/cdn.../cosign
```

Implements [SECURESIGN-2158](https://redhat.atlassian.net/browse/SECURESIGN-2158)

[SECURESIGN-2158]: https://redhat.atlassian.net/browse/SECURESIGN-2158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ