### PR TITLE
fix: add cgwName_os candidate to FindBinary for inconsistent archives

### DIFF
--- a/pkg/support/cgw.go
+++ b/pkg/support/cgw.go
@@ -26,6 +26,7 @@ func FindBinary(dir, cliName, goos, goarch string) (string, error) {
 	candidates := []string{
 		cliName,
 		fmt.Sprintf("%s_%s_%s", cgwName, goos, goarch),
+		fmt.Sprintf("%s_%s", cgwName, goos),
 		fmt.Sprintf("%s-%s-%s", cliName, goos, goarch),
 	}
 	if goos == "windows" {


### PR DESCRIPTION
## Summary

Add `cgwName_os` (e.g., `gitsign_cli_linux`) as a candidate pattern in `FindBinary`. Some CLI archives from the Developer Portal contain binaries without the arch suffix.

## Binary naming in 1.4.1 archives

| CLI | Binary inside archive | Matched by |
|---|---|---|
| cosign | `cosign` | `cliName` |
| rekor-cli | `rekor_cli_linux` | `cgwName_os` **(new)** |
| gitsign | `gitsign_cli_linux` | `cgwName_os` **(new)** |
| ec | `ec_linux_amd64` | `cgwName_os_arch` |
| fetch-tsa-certs | `fetch_tsa_certs_linux` | `cgwName_os` **(new)** |
| createtree | `createtree` | `cliName` |
| updatetree | `updatetree` | `cliName` |
| tuftool | `tuftool` | `cliName` |

## Verified

All 8 CLIs tested against actual CDN archives from 1.4.1 — 8/8 pass.

Implements [SECURESIGN-2158](https://redhat.atlassian.net/browse/SECURESIGN-2158)

[SECURESIGN-2158]: https://redhat.atlassian.net/browse/SECURESIGN-2158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ