### PR TITLE
fix: simplify download fallback and fix resource leaks

### DIFF
--- a/pkg/strategy/openshift/openshift.go
+++ b/pkg/strategy/openshift/openshift.go
@@ -26,8 +26,7 @@ func init() {
 
 const (
 	prodHost        = "developers.redhat.com"
-	stagingHost     = "developers.qa.redhat.com"
-	fallbackVersion = "1.4.1"
+	fallbackVersion = "1.4.2"
 )
 
 var versionRegexp = regexp.MustCompile(`/RHTAS/[^/]+/`)
@@ -42,20 +41,14 @@ func download(ctx context.Context, client controller.Reader, cliName string) (st
 	if isTarGz(link) {
 		path, err := downloadTarGz(ctx, cliName, link)
 		if err != nil && strings.Contains(link, prodHost) {
-			stagingLink := strings.Replace(link, prodHost, stagingHost, 1)
-			logrus.Infof("Production download failed, falling back to staging: %s", stagingLink)
-			path, err = downloadTarGz(ctx, cliName, stagingLink)
-			if err != nil {
-				fallbackLink := versionRegexp.ReplaceAllString(link, "/RHTAS/"+fallbackVersion+"/")
-				logrus.Infof("Staging download failed, falling back to stable %s via CDN: %s", fallbackVersion, fallbackLink)
-				cdnLink, cdnErr := support.ResolveCDNLink(ctx, fallbackLink)
-				if cdnErr != nil {
-					return "", fmt.Errorf("all download attempts failed (prod, staging, CDN fallback): %w", cdnErr)
-				}
-				logrus.Infof("Resolved CDN link: %s", cdnLink)
-				return downloadTarGz(ctx, cliName, cdnLink)
+			fallbackLink := versionRegexp.ReplaceAllString(link, "/RHTAS/"+fallbackVersion+"/")
+			logrus.Infof("Download failed, falling back to stable %s via CDN: %s", fallbackVersion, fallbackLink)
+			cdnLink, cdnErr := support.ResolveCDNLink(ctx, fallbackLink)
+			if cdnErr != nil {
+				return "", fmt.Errorf("all download attempts failed (current version, CDN fallback %s): %w", fallbackVersion, cdnErr)
 			}
-			return path, nil
+			logrus.Infof("Resolved CDN link: %s", cdnLink)
+			return downloadTarGz(ctx, cliName, cdnLink)
 		}
 		return path, err
 	}
@@ -79,6 +72,7 @@ func downloadTarGz(ctx context.Context, cliName string, link string) (string, er
 	}
 
 	if err = support.DownloadAndUntarArchive(ctx, link, tmp); err != nil {
+		os.RemoveAll(tmp)
 		return "", err
 	}
 

--- a/pkg/strategy/openshift/openshift.go
+++ b/pkg/strategy/openshift/openshift.go
@@ -72,7 +72,7 @@ func downloadTarGz(ctx context.Context, cliName string, link string) (string, er
 	}
 
 	if err = support.DownloadAndUntarArchive(ctx, link, tmp); err != nil {
-		os.RemoveAll(tmp)
+		_ = os.RemoveAll(tmp)
 		return "", err
 	}
 

--- a/pkg/support/cgw.go
+++ b/pkg/support/cgw.go
@@ -23,12 +23,15 @@ func ContentGatewayName(name string) string {
 // FindBinary searches for a CLI binary in the given directory using candidate name patterns.
 func FindBinary(dir, cliName, goos, goarch string) (string, error) {
 	cgwName := ContentGatewayName(cliName)
-	candidates := []string{
-		cliName,
+	candidates := []string{cliName}
+	if cgwName != cliName {
+		candidates = append(candidates, cgwName)
+	}
+	candidates = append(candidates,
 		fmt.Sprintf("%s_%s_%s", cgwName, goos, goarch),
 		fmt.Sprintf("%s_%s", cgwName, goos),
 		fmt.Sprintf("%s-%s-%s", cliName, goos, goarch),
-	}
+	)
 	if goos == "windows" {
 		for i, name := range candidates {
 			candidates[i] = name + ".exe"
@@ -38,6 +41,12 @@ func FindBinary(dir, cliName, goos, goarch string) (string, error) {
 	for _, name := range candidates {
 		path := filepath.Join(dir, name)
 		if _, err := os.Stat(path); err == nil {
+			if name != cliName {
+				link := filepath.Join(dir, cliName)
+				if err := os.Symlink(path, link); err == nil {
+					return link, nil
+				}
+			}
 			return path, nil
 		}
 	}

--- a/pkg/support/testSupport.go
+++ b/pkg/support/testSupport.go
@@ -65,6 +65,7 @@ func GitCloneWithAuth(url string, auth transport.AuthMethod) (string, *git.Repos
 
 func DownloadAndUnzip(ctx context.Context, link string, writer io.Writer) error {
 	pr, pw := io.Pipe()
+	defer pr.Close()
 
 	go func() {
 		_, err := Download(ctx, link, pw)
@@ -75,6 +76,7 @@ func DownloadAndUnzip(ctx context.Context, link string, writer io.Writer) error 
 
 func DownloadAndUntarArchive(ctx context.Context, link string, dst string) error {
 	pr, pw := io.Pipe()
+	defer pr.Close()
 
 	go func() {
 		_, err := Download(ctx, link, pw)
@@ -83,30 +85,8 @@ func DownloadAndUntarArchive(ctx context.Context, link string, dst string) error
 	return UntarArchive(dst, pr)
 }
 
-const squidProxy = "http://squid.corp.redhat.com:3128"
-
-var stagingProxySuffixes = []string{
-	".qa.redhat.com",
-	".dev.redhat.com",
-	".stage.redhat.com",
-	".preprod.redhat.com",
-}
-
-func proxyForStagingOnly(req *http.Request) (*url.URL, error) {
-	host := req.URL.Hostname()
-	for _, suffix := range stagingProxySuffixes {
-		if strings.HasSuffix(host, suffix) {
-			return url.Parse(squidProxy)
-		}
-	}
-	return nil, nil
-}
-
 func Download(ctx context.Context, link string, writer io.Writer) (int64, error) {
-	client := &http.Client{
-		Timeout:   2 * time.Minute, //nolint:mnd
-		Transport: &http.Transport{Proxy: proxyForStagingOnly},
-	}
+	client := &http.Client{Timeout: 2 * time.Minute} //nolint:mnd
 
 	const maxRetries = 5
 	var lastErr error
@@ -136,8 +116,13 @@ func Download(ctx context.Context, link string, writer io.Writer) (int64, error)
 			lastErr = fmt.Errorf("bad status: %s", resp.Status)
 			continue
 		}
-		defer resp.Body.Close()
-		return io.Copy(writer, resp.Body)
+		n, copyErr := io.Copy(writer, resp.Body)
+		resp.Body.Close()
+		if copyErr != nil {
+			lastErr = copyErr
+			continue
+		}
+		return n, nil
 	}
 	return 0, fmt.Errorf("download failed after %d attempts: %w", maxRetries, lastErr)
 }


### PR DESCRIPTION
## Summary

Simplify the openshift strategy download fallback and fix several resource leaks found during audit.

### Fallback chain (simplified)

| Tier | Source | When |
|---|---|---|
| 1 | Production `developers.redhat.com/.../RHTAS/<current-version>/...` | Post-release |
| 2 | CDN fallback via `developers.redhat.com/.../RHTAS/1.4.2/...` redirect resolution | Pre-release or current version unavailable |

### Removed

- Staging Developer Portal fallback (`developers.qa.redhat.com`) — not accessible outside RH VPN
- Squid proxy configuration (`proxyForStagingOnly`, `stagingProxySuffixes`)

### Bug fixes 

| ID | Fix | File |
|---|---|---|
| C1 | Fix goroutine + pipe reader leak on failed downloads | `testSupport.go` — `defer pr.Close()` |
| C3 | Clean up temp directories on download failure | `openshift.go` — `os.RemoveAll(tmp)` |
| M1 | Add bare `cgwName` as `FindBinary` candidate | `cgw.go` — handles `gitsign_cli`, `rekor_cli` |
| M4 | Retry body-read errors during download | `testSupport.go` — explicit `resp.Body.Close()` |

### Verified

- All `go test ./pkg/...` pass
- All 8 CLIs verified against CDN archives from 1.4.1

Implements [SECURESIGN-2158](https://redhat.atlassian.net/browse/SECURESIGN-2158)

[SECURESIGN-2158]: https://redhat.atlassian.net/browse/SECURESIGN-2158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ