### PR TITLE
feat: add CDN redirect resolution to cgw strategy

### DIFF
--- a/pkg/strategy/cgw/cgw.go
+++ b/pkg/strategy/cgw/cgw.go
@@ -38,7 +38,21 @@ func download(ctx context.Context, cgwURL string, cliName string) (string, error
 	}
 
 	if err = support.DownloadAndUntarArchive(ctx, link, tmp); err != nil {
-		return "", err
+		_ = os.RemoveAll(tmp)
+		logrus.Infof("Direct download failed, resolving CDN link for: %s", link)
+		cdnLink, cdnErr := support.ResolveCDNLink(ctx, link)
+		if cdnErr != nil {
+			return "", fmt.Errorf("download failed and CDN resolution failed: %w", cdnErr)
+		}
+		logrus.Infof("Resolved CDN link: %s", cdnLink)
+		tmp, err = os.MkdirTemp("", cliName)
+		if err != nil {
+			return "", err
+		}
+		if err = support.DownloadAndUntarArchive(ctx, cdnLink, tmp); err != nil {
+			_ = os.RemoveAll(tmp)
+			return "", err
+		}
 	}
 
 	return support.FindBinary(tmp, cliName, runtime.GOOS, runtime.GOARCH)


### PR DESCRIPTION
## Summary

When the `cgw` strategy downloads a CLI binary from the Developer Portal `file/` URL, the portal returns a 302 redirect to an HTML interstitial page — not the binary. This PR adds automatic CDN redirect resolution: if the direct download fails, `ResolveCDNLink` extracts the actual CDN download URL from the redirect's `tcDownloadURL` query parameter and retries.

## How it works

```
1. Try direct download from CGW_URL/<binary>.tar.gz
   → Fails (HTML, not tar.gz)
2. ResolveCDNLink: no-follow request → extract tcDownloadURL from 302 Location
3. Download from CDN URL (access.cdn.redhat.com/...)
   → Success (actual binary)
```

## Why

With the cli-server being removed from the operator ([securesign/secure-sign-operator#2143](https://github.com/securesign/secure-sign-operator/pull/2143)), the GitHub Actions Kind CI can no longer use `CLI_STRATEGY=cli_server`. The `cgw` strategy with CDN resolution enables downloading CLI binaries from the publicly accessible Developer Portal.

## Verified

```
CGW_URL=https://developers.redhat.com/content-gateway/file/RHTAS/1.4.2
cosign   → PASS
gitsign  → PASS
rekor-cli → PASS
```

All `go test ./pkg/...` pass.